### PR TITLE
Split CI workflow into separate production and development workflows

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,72 @@
+name: Development
+on:
+  schedule:
+    # Daily rebuild of dev images
+    - cron: "45 4 * * *" # At 04:45 every day
+
+  pull_request:
+
+  push:
+    branches:
+      - main
+
+concurrency:
+  # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
+  # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: CI
+    # This should be the only action checked as required in the repo settings.
+    #
+    # This is a meta-job, here to express the conditions we require
+    # in order to consider a CI run to be successful.
+    if: always()
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - build
+
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: clean
+
+  build:
+    name: Build
+    # Build all development versions of each image in parallel.
+    permissions:
+      contents: read
+      packages: write
+
+    uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    with:
+      runs-on: ubuntu-latest-4x
+      dev-versions: "only"
+      # Push images only for merges into main and daily schduled re-builds.
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
+
+  clean:
+    name: Clean
+    if: always() && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - build
+
+    uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
+    with:
+      remove-dangling-caches: true
+      remove-caches-older-than: 14
+      # FIXME: re-enable temporary image cleanup after moving to native platform workflow
+      # remove-dangling-temporary-images: false
+      # remove-temporary-images-older-than: 3
+      clean-temporary-images: false

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,10 +1,8 @@
-name: CI
+name: Production
 on:
   schedule:
     # Weekly rebuild of all images, to pick up any upstream changes.
     - cron: "15 3 * * 0" # At 03:15 on Sunday
-    # Hourly rebuild of dev images
-    - cron: "45 4 * * *" # At 04:45 every day
 
   pull_request:
 
@@ -31,31 +29,18 @@ jobs:
     timeout-minutes: 10
     needs:
       - build
-      - dev
 
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: ${{
-              (
-                github.event_name == 'schedule' &&
-                (
-                  github.event.schedule != '15 3 * * 0' && '["build"]'
-                  ||
-                  github.event.schedule != '45 4 * * 0' && '["dev"]'
-                )
-              ) || '[]'
-            }}
+          allowed-skips: clean
 
   build:
     name: Build
     # Build all images, excluding dev versions.
     #
     # Builds all versions of each image in parallel.
-    #
-    # Run on merges to main, or on weekly scheduled re-builds.
-    if: contains(fromJSON('["push", "pull_request"]'), github.event_name) || github.event.schedule == '15 3 * * 0'
     permissions:
       contents: read
       packages: write
@@ -67,27 +52,7 @@ jobs:
       runs-on: ubuntu-latest-4x
       dev-versions: "exclude"
       # Push images only for merges into main and weekly schduled re-builds.
-      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event.schedule == '15 3 * * 0' }}
-
-  dev:
-    name: Dev Build
-    # Dev Build
-    #
-    # Builds all development versions of each image in parallel.
-    #
-    # Run on merges to main, or on daily scheduled re-builds.
-    if: contains(fromJSON('["push", "pull_request"]'), github.event_name) || github.event.schedule == '45 4 * * *'
-
-    permissions:
-      contents: read
-      packages: write
-
-    uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
-    with:
-      runs-on: ubuntu-latest-4x
-      dev-versions: "only"
-      # Push images only for merges into main and daily schduled re-builds.
-      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event.schedule == '45 4 * * *' }}
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
 
   clean:
     name: Clean
@@ -97,7 +62,6 @@ jobs:
       packages: write
     needs:
       - build
-      - dev
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:


### PR DESCRIPTION
## Summary
- Separates combined ci.yml into dedicated production.yml and development.yml workflows
- Each workflow has its own schedule, CI meta-job, and clean job
- Simplifies allowed-skips logic since schedules are no longer shared

## Test plan
- [ ] Verify production workflow runs on PR
- [ ] Verify development workflow runs on PR
- [ ] Check that CI meta-job correctly ignores clean job status

🤖 Generated with [Claude Code](https://claude.com/claude-code)