### PR TITLE
Restructure docs for usage-first, add connect-content README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,119 @@
 
 Container images for [Posit Connect](https://docs.posit.co/connect/).
 
-> [!IMPORTANT]
-> These images are under active development and testing and are not yet supported by Posit.
->
-> Please see [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products) for officially supported images.
+> [!NOTE]
+> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The existing images remain supported.
+
+## Prerequisites
+
+| Tool | Required for | Install |
+|------|-------------|---------|
+| [Docker](https://docs.docker.com/get-docker/) | Running containers locally | [Get Docker](https://docs.docker.com/get-docker/) |
+| [Helm](https://helm.sh/docs/intro/install/) | Deploying on Kubernetes | [Install Helm](https://helm.sh/docs/intro/install/) |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | Deploying on Kubernetes | [Install kubectl](https://kubernetes.io/docs/tasks/tools/) |
+| Product license | Running Posit Connect | [Licensing FAQ](https://docs.posit.co/licensing/licensing-faq.html) |
 
 ## Images
 
 | Image | Docker Hub | GitHub Container Registry |
 |:------|:-----------|:--------------------------|
-| [connect](./connect/) | `docker.io/posit/connect` | [`ghcr.io/posit-dev/connect`](https://github.com/posit-dev/images-connect/pkgs/container/connect) |
-| [connect-content](./connect-content/) | `docker.io/posit/connect-content` | [`ghcr.io/posit-dev/connect-content`](https://github.com/posit-dev/images-connect/pkgs/container/connect-content) |
-| [connect-content-init](./connect-content-init/) | `docker.io/posit/connect-content-init` | [`ghcr.io/posit-dev/connect-content-init`](https://github.com/posit-dev/images-connect/pkgs/container/connect-content-init) |
+| [connect](./connect/) | [`docker.io/posit/connect`](https://hub.docker.com/r/posit/connect) | [`ghcr.io/posit-dev/connect`](https://github.com/posit-dev/images-connect/pkgs/container/connect) |
+| [connect-content](./connect-content/) | [`docker.io/posit/connect-content`](https://hub.docker.com/r/posit/connect-content) | [`ghcr.io/posit-dev/connect-content`](https://github.com/posit-dev/images-connect/pkgs/container/connect-content) |
+| [connect-content-init](./connect-content-init/) | [`docker.io/posit/connect-content-init`](https://hub.docker.com/r/posit/connect-content-init) | [`ghcr.io/posit-dev/connect-content-init`](https://github.com/posit-dev/images-connect/pkgs/container/connect-content-init) |
 
 Additional Posit container images are published to [Docker Hub](https://hub.docker.com/u/posit) and [GitHub Container Registry](https://github.com/orgs/posit-dev/packages).
 
-## Getting Started
+## Running the Images
+
+For local Docker, you only need the `connect` image. The `connect-content` and `connect-content-init` images are for Kubernetes deployments, where published content runs in separate pods from the Connect server.
+
+- [Posit Connect](./connect/) — The Connect server
+- [Connect Content](./connect-content/) — Runtime images for executing content (Kubernetes)
+- [Connect Content Init](./connect-content-init/) — Init container for Kubernetes deployments
+
+See the [Connect installation guide](https://docs.posit.co/connect/admin/getting-started/installation/) for full setup instructions.
+
+## Deploying on Kubernetes
+
+Use the [Posit Connect Helm chart](https://docs.posit.co/helm/charts/rstudio-connect/README.html) to deploy on Kubernetes.
+
+```bash
+helm repo add rstudio https://helm.rstudio.com
+helm repo update
+```
+
+Create a Kubernetes secret from your license file, then configure the chart in your `values.yaml`:
+
+```bash
+kubectl create secret generic posit-connect-license \
+  --from-file=license.lic=/path/to/license.lic
+```
+
+The `executionEnvironments` list uses [declarative management](https://docs.posit.co/connect/admin/appendix/off-host/execution-environments/#declarative-management) (Connect 2026.03.0+). Unlike the legacy `customRuntimeYaml`, changes take effect on every `helm upgrade` without requiring a pod restart or database reset. Setting `customRuntimeYaml` to an empty images list prevents the chart from bootstrapping its default set of 12 content images on first start.
+
+```yaml
+image:
+  repository: ghcr.io/posit-dev/connect
+  tag: "2026.03.0"
+
+license:
+  file:
+    secret: posit-connect-license
+
+launcher:
+  # Suppress the default runtime.yaml bootstrap so only
+  # executionEnvironments images are registered.
+  customRuntimeYaml: |
+    name: Kubernetes
+    images: []
+  defaultInitContainer:
+    repository: ghcr.io/posit-dev/connect-content-init
+    tag: "2026.03.0"
+
+executionEnvironments:
+  - name: ghcr.io/posit-dev/connect-content:R4.5.2-python3.14.3-ubuntu-24.04
+    title: "R 4.5.2 / Python 3.14.3"
+    matching: any
+    r:
+      installations:
+        - version: "4.5.2"
+          path: /opt/R/4.5.2/bin/R
+    python:
+      installations:
+        - version: "3.14.3"
+          path: /opt/python/3.14.3/bin/python3
+    quarto:
+      installations:
+        - version: "1.8.27"
+          path: /opt/quarto/1.8.27/bin/quarto
+  - name: ghcr.io/posit-dev/connect-content:R4.4.3-python3.12.12-ubuntu-24.04
+    title: "R 4.4.3 / Python 3.12.12"
+    matching: any
+    r:
+      installations:
+        - version: "4.4.3"
+          path: /opt/R/4.4.3/bin/R
+    python:
+      installations:
+        - version: "3.12.12"
+          path: /opt/python/3.12.12/bin/python3
+    quarto:
+      installations:
+        - version: "1.8.27"
+          path: /opt/quarto/1.8.27/bin/quarto
+```
+
+Content image tags follow the pattern `R{r_version}-python{python_version}-{os}`. Append `-pro` for images with Posit Professional Drivers.
+
+Install the chart:
+
+```bash
+helm upgrade --install connect rstudio/rstudio-connect --values values.yaml
+```
+
+See the [full chart documentation](https://docs.posit.co/helm/charts/rstudio-connect/README.html) for all available values.
+
+## Building from Source
 
 You can interact with this repository in multiple ways:
 
@@ -36,24 +133,24 @@ The root of the bakery project is used as the build context for each Containerfi
 Here, the [`bakery.yaml`](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md#bakery-configuration) file, or project, is in the root of this repository.
 
 ```shell
-PCT_VERSION="2025.12"
+PCT_VERSION="2026.02"
 
 # Build the standard Connect image using docker
 docker buildx build \
     --tag connect:${PCT_VERSION} \
-    --file connect/${PCT_VERSION}/Containerfile.ubuntu2204.std \
+    --file connect/${PCT_VERSION}/Containerfile.ubuntu2404.std \
     .
 
 # Build the minimal Connect image using buildah
 buildah build \
     --tag connect:${PCT_VERSION} \
-    --file connect/${PCT_VERSION}/Containerfile.ubuntu2204.min \
+    --file connect/${PCT_VERSION}/Containerfile.ubuntu2404.min \
     .
 
 # Build the minimal Connect image using podman
 podman build \
     --tag connect:${PCT_VERSION} \
-    --file connect/${PCT_VERSION}/Containerfile.ubuntu2204.min \
+    --file connect/${PCT_VERSION}/Containerfile.ubuntu2404.min \
     .
 ```
 
@@ -88,7 +185,7 @@ Build prerequisites
 
 ### Build with `bakery`
 
-By default, bakery creates a ephemeral JSON [bakefile](https://docs.bakefile.org/en/latest/language.html) to render all containers in parallel.
+By default, bakery creates an ephemeral JSON [bakefile](https://docs.bakefile.org/en/latest/language.html) to render all containers in parallel.
 
 ```shell
 bakery build

--- a/connect-content-init/README.md
+++ b/connect-content-init/README.md
@@ -2,10 +2,8 @@
 
 This container image is an "init container" used to pull runtime components into another container, which can then be used with Posit Connect and Launcher to build and run content. This image is primarily used in Kubernetes deployments and is leveraged by the Posit Connect Helm chart.
 
-> [!IMPORTANT]
-> This image is under active development and testing and is not yet supported by Posit.
->
-> Please see [rstudio-connect-content-init image](https://github.com/rstudio/rstudio-docker-products/tree/main/connect-content-init) in `rstudio/rstudio-docker-products` for the officially supported image.
+> [!NOTE]
+> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The existing images remain supported.
 
 ## Overview
 
@@ -20,9 +18,9 @@ Images are published to:
 - GitHub Container Registry: `ghcr.io/posit-dev/connect-content-init`
 
 Tag formats:
-- `2025.11.0` - Full version (Ubuntu 22.04)
-- `2025.11.0-ubuntu-22.04` - Explicit OS
-- `latest` - Latest stable release (currently 2025.11.0, Ubuntu 22.04)
+- `2026.02.0` - Full version (Ubuntu 24.04)
+- `2026.02.0-ubuntu-24.04` - Explicit OS
+- `latest` - Latest stable release (Ubuntu 24.04)
 
 ## Usage
 
@@ -33,7 +31,7 @@ This image is designed to be used as an init container in Kubernetes. It copies 
 ```yaml
 initContainers:
   - name: connect-content-init
-    image: posit/connect-content-init:2025.11.0
+    image: ghcr.io/posit-dev/connect-content-init:2026.02.0
     volumeMounts:
       - name: connect-runtime
         mountPath: /opt/rstudio-connect-runtime
@@ -50,7 +48,7 @@ This image differs from the legacy [`rstudio/rstudio-connect-content-init`](http
 | Aspect           | This Image                      | rstudio/rstudio-connect-content-init |
 |------------------|---------------------------------|--------------------------------------|
 | Registry         | `posit/connect-content-init`    | `rstudio/rstudio-connect-content-init` |
-| Base OS options  | Ubuntu 22.04                    | Ubuntu 22.04                         |
+| Base OS options  | Ubuntu 24.04, Ubuntu 22.04      | Ubuntu 22.04                         |
 
 ## Caveats
 

--- a/connect-content/README.md
+++ b/connect-content/README.md
@@ -1,0 +1,63 @@
+# Posit Connect Content Container Images
+
+These container images provide the runtime environments for executing content deployed to [Posit Connect](https://docs.posit.co/connect/) in Kubernetes. Each image includes a specific combination of R, Python, and Quarto.
+
+> [!NOTE]
+> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The existing images remain supported.
+
+## Overview
+
+When Posit Connect runs on Kubernetes with the Job Launcher, published content (Shiny apps, Plumber APIs, Quarto documents, Jupyter notebooks, etc.) executes inside content containers. Each content image provides a specific R and Python version pair.
+
+## Image Variants
+
+| Variant | Tag Suffix | Description |
+|---------|------------|-------------|
+| Base | (none) | Open-source R and Python |
+| Pro | `-pro` | Includes Posit Professional Drivers for database connectivity |
+
+## Image Tags
+
+Images are published to:
+- Docker Hub: `docker.io/posit/connect-content`
+- GitHub Container Registry: `ghcr.io/posit-dev/connect-content`
+
+Tag format: `R{r_version}-python{python_version}-{os}[-pro]`
+
+Examples:
+- `R4.5.2-python3.14.3-ubuntu-24.04` — R 4.5.2, Python 3.14.3, Ubuntu 24.04
+- `R4.4.3-python3.12.12-ubuntu-24.04-pro` — Same versions with pro drivers
+
+## Available Versions
+
+The standard set of content images covers a matrix of R and Python versions:
+
+| R Version | Python Versions |
+|-----------|----------------|
+| 4.5.2 | 3.14.3, 3.13.12, 3.12.12, 3.11.14 |
+| 4.4.3 | 3.14.3, 3.13.12, 3.12.12, 3.11.14 |
+| 4.3.3 | 3.14.3, 3.13.12, 3.12.12, 3.11.14 |
+
+## Usage
+
+These images are not run directly. They are configured as execution environments in Posit Connect, either through:
+
+1. **Helm chart values** — The `rstudio/rstudio-connect` Helm chart includes a default set of content images. See the [repository README](../README.md#deploying-on-kubernetes) for configuration details.
+2. **Connect admin dashboard** — Execution environments can be managed in the Connect UI under Admin > Execution Environments.
+3. **runtime.yaml** — A YAML configuration file defining available execution environments.
+
+## Installed Software
+
+Each image includes:
+
+| Component | Path |
+|-----------|------|
+| R | `/opt/R/{version}/bin/R` |
+| Python | `/opt/python/{version}/bin/python3` |
+| Quarto | `/opt/quarto/{version}/bin/quarto` |
+
+## Documentation
+
+- [Posit Connect Content Images](https://docs.posit.co/connect/admin/runtimes/content-images/)
+- [Posit Connect Documentation](https://docs.posit.co/connect/)
+- [Posit Connect Helm Chart](https://docs.posit.co/helm/charts/rstudio-connect/README.html)

--- a/connect/README.md
+++ b/connect/README.md
@@ -2,29 +2,33 @@
 
 This container image provides [Posit Connect](https://docs.posit.co/connect/) (PCT), a publishing platform that connects you and the work you do with others. Deploy Shiny applications, R Markdown documents, Plumber APIs, Python applications (Flask, Dash, FastAPI, Bokeh, Streamlit), Jupyter notebooks, Quarto documents, and more.
 
-> [!IMPORTANT]
-> This image is under active development and testing and is not yet supported by Posit.
->
-> Please see [rstudio-connect image](https://github.com/rstudio/rstudio-docker-products/tree/main/connect) in `rstudio/rstudio-docker-products` for the officially supported image.
+> [!NOTE]
+> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The existing images remain supported.
 
 ## Quick Start
 
 ```bash
-PCT_VERSION="2025.12.1"
+PCT_VERSION="2026.02.0"
+PCT_IMAGE="ghcr.io/posit-dev/connect"  # or docker.io/posit/connect
+PCT_LICENSE="/path/to/license.lic"
 docker run -d \
   --name connect \
   --privileged \
   -p 3939:3939 \
-  -v /path/to/license.lic:/etc/rstudio-connect/license.lic \
-  posit/connect:${PCT_VERSION}-ubuntu-22.04
+  -v ${PCT_LICENSE}:/etc/rstudio-connect/license.lic \
+  ${PCT_IMAGE}:${PCT_VERSION}
 ```
 
 Access Posit Connect at `http://localhost:3939`.
 
-> IMPORTANT: To use Posit Connect with more than one user, you will need to
-> define `Server.Address` in the `rstudio-connect.gcfg` file. Update your
-> configuration file with the URL that users will use to visit Connect,
-> then start or restart the container.
+> [!NOTE]
+> The `--privileged` flag is required for Connect to manage sandboxed content execution environments.
+> This example does not mount a data volume. Application data will not persist when the container stops. See [Volume Mounts](#volume-mounts) for persistent storage.
+
+> [!IMPORTANT]
+> To use Posit Connect with more than one user, define `Server.Address` in
+> the `rstudio-connect.gcfg` file. Set it to the URL that users will use to
+> visit Connect, then start or restart the container.
 
 ## Image Variants
 
@@ -43,17 +47,20 @@ Images are published to:
 - Docker Hub: `docker.io/posit/connect`
 - GitHub Container Registry: `ghcr.io/posit-dev/connect`
 
+Ubuntu 24.04 is the default OS.
+
 Tag formats:
-- `2025.12.1` - Full version (standard variant, Ubuntu 22.04)
-- `2025.12.1-ubuntu-22.04-std` - Explicit OS and variant
-- `2025.12.1-ubuntu-22.04-min` - Minimal variant
-- `latest` - Latest stable release (standard variant, Ubuntu 22.04)
+- `2026.02.0` - Latest OS, standard variant
+- `2026.02.0-ubuntu-24.04` - Explicit OS, standard variant
+- `2026.02.0-ubuntu-24.04-std` - Explicit OS and variant
+- `2026.02.0-ubuntu-24.04-min` - Minimal variant
+- `latest` - Latest version, default OS, standard variant
 
 ## Configuration
 
 ### License Activation
 
-A valid license is required. Posit Connect must also run with the `--privileged` flag. Choose one license activation method:
+A [product license](https://docs.posit.co/licensing/licensing-faq.html) is required. Posit recommends license file activation. Connect must also run with the `--privileged` flag. Choose one activation method:
 
 **Option 1: License File (Recommended)**
 ```bash
@@ -139,7 +146,7 @@ This image differs from the legacy [`rstudio/rstudio-connect`](https://hub.docke
 | Registry         | `posit/connect`                        | `rstudio/rstudio-connect`                                     |
 | License env vars | `PCT_` prefix                          | `RSC_` prefix                                                 |
 | Variants         | `std` (with R/Python), `min` (minimal) | Single variant; multiple tags for different R/Python versions |
-| Base OS options  | Ubuntu 22.04                           | Ubuntu 22.04                                                  |
+| Base OS options  | Ubuntu 24.04, Ubuntu 22.04             | Ubuntu 22.04                                                  |
 
 ## Caveats
 


### PR DESCRIPTION
## Summary

Restructure documentation to lead with running images and Helm deployment, moving build instructions below.

**Top-level README:**
- Add prerequisites (Docker, Helm, kubectl, product license)
- Add "Running the Images" section explaining which images are needed for Docker vs Kubernetes
- Add Helm deployment with license secret, explicit tags, and `customRuntimeYaml` content image configuration
- Add installation guide link
- Update build examples to latest version and ubuntu2404
- Add hyperlinks to Docker Hub and GHCR in image table

**connect/README.md:**
- Use short version tag and license path env var in Quick Start
- Add privileged flag and data persistence notes
- Document Ubuntu 24.04 as default OS with all tag formats
- Use product license terminology with Licensing FAQ link
- Use `[!IMPORTANT]` callout for `Server.Address` note

**connect-content/README.md (new):**
- Document content runtime images, tag format, version matrix, and usage patterns

**connect-content-init/README.md:**
- Update status banner and OS defaults to Ubuntu 24.04

**All READMEs:**
- Update status banner to preview language

Part of a coordinated documentation update across the Posit Container Image ecosystem.