### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Product version (e.g. 2026.03.0)"
+        required: true
+        type: string
+
+jobs:
+  release:
+    uses: posit-dev/images-shared/.github/workflows/product-release.yml@main
+    with:
+      version: ${{ inputs.version }}
+      images: "connect connect-content-init"
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow that automates version creation and patching when a new product version ships. Accepts a version string, determines whether to create a new edition or patch an existing one, updates README version references, and opens a PR.

Uses GitHub App token so CI runs automatically on the created PR.

**Images:** `connect`, `connect-content-init`

> **Note:** The second commit (`REVERTME`) temporarily points `setup-bakery` at the feature branch in images-shared for testing. Must be reverted before merging.

**Depends on:** posit-dev/images-shared#393

## Test plan

- [ ] Trigger workflow with `version: 2026.03.0` and verify PR is created
- [ ] Verify bakery.yaml has new version with correct subpath and latest flag
- [ ] Verify READMEs are updated
- [ ] Revert REVERTME commit before merging