### PR TITLE
Replace pipx with uv tool install

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Additional documentation:
 Build prerequisites
 
 * [python](https://docs.astral.sh/uv/guides/install-python/)
-* [pipx](https://pipx.pypa.io/stable/how-to/install-pipx/)
+* [uv](https://docs.astral.sh/uv/getting-started/installation/)
 * [docker buildx bake](https://github.com/docker/buildx#installing)
 * [just](https://just.systems/man/en/prerequisites.html)
 * `bakery`

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ GITHUB_TOKEN := `gh auth token`
 install-bakery *OPTS:
   #!/bin/bash
   # TODO: Update this after package is published somewhere
-  pipx install {{OPTS}} 'git+ssh://git@github.com/posit-dev/images-shared.git@main#egg=posit-bakery&subdirectory=posit-bakery'
+  uv tool install {{OPTS}} 'git+ssh://git@github.com/posit-dev/images-shared.git@main#egg=posit-bakery&subdirectory=posit-bakery'
 
 install-goss:
   #!/bin/bash


### PR DESCRIPTION
## Summary
- Replace `pipx install` with `uv tool install` in the justfile
- Update README build prerequisites to link to uv instead of pipx

## Test plan
- [x] Verify `just install-bakery` works with `uv tool install`