### PR TITLE
Split Quarto and TinyTeX into separate layers

### DIFF
--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -69,8 +69,13 @@ COPY --from=python-builder /opt/python /opt/python
 RUN /opt/python/$PYTHON_VERSION/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+
+### Install TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
+ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -82,8 +82,13 @@ COPY --from=python-builder /opt/python /opt/python
 RUN /opt/python/$PYTHON_VERSION/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+
+### Install TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
+ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -69,8 +69,13 @@ COPY --from=python-builder /opt/python /opt/python
 RUN /opt/python/$PYTHON_VERSION/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+
+### Install TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
+ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -84,8 +84,13 @@ COPY --from=python-builder /opt/python /opt/python
 RUN /opt/python/$PYTHON_VERSION/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+
+### Install TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
+ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    rm -f /tmp/tinytex-release.json

--- a/connect-content/template/Containerfile.ubuntu2204.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2204.jinja2
@@ -68,7 +68,12 @@ RUN {{ r.get_version_directory(r.build_arg()) }}/bin/R -e 'install.packages("odb
 RUN {{ python.get_version_directory(python.build_arg()) }}/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.install(quarto.build_arg(), False, True) | indent(4) }} && \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
+RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
     {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }}
+
+### Install TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
+ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+RUN {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
+    rm -f /tmp/tinytex-release.json

--- a/connect-content/template/Containerfile.ubuntu2404.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2404.jinja2
@@ -70,7 +70,12 @@ RUN {{ r.get_version_directory(r.build_arg()) }}/bin/R -e 'install.packages("odb
 RUN {{ python.get_version_directory(python.build_arg()) }}/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.install(quarto.build_arg(), False, True) | indent(4) }} && \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
+RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
     {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }}
+
+### Install TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
+ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+RUN {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
+    rm -f /tmp/tinytex-release.json


### PR DESCRIPTION
## Summary

- Split the connect-content Quarto+TinyTeX install into separate layers. The TinyTeX ADD cache buster was positioned before a single RUN that downloaded Quarto AND installed TinyTeX, so a TinyTeX release forced a Quarto re-download. Quarto now installs in its own layer; the ADD cache buster only invalidates the TinyTeX install.

Addresses posit-dev/images-shared#138.

## Test plan

- [ ] Rendered Containerfiles have Quarto install and TinyTeX install as separate RUN instructions
- [ ] Build connect-content image and verify both Quarto and TinyTeX are installed correctly