### PR TITLE
Add workflow_dispatch trigger to all build workflows

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -1,5 +1,7 @@
 name: Content Image
 on:
+  workflow_dispatch:
+
   schedule:
     # Weekly rebuild of all images, to pick up any upstream changes.
     - cron: "15 4 * * 0" # At 04:15 on Sunday
@@ -57,7 +59,7 @@ jobs:
     with:
       matrix-versions: "only"
       # Push images only for merges into main and weekly scheduled re-builds.
-      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event.schedule == '15 4 * * 0' }}
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 
   clean:
     name: Clean

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -57,7 +57,7 @@ jobs:
       dev-versions: "only"
       matrix-versions: "exclude"
       # Push images only for merges into main and daily schduled re-builds.
-      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 
   clean:
     name: Clean

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,5 +1,7 @@
 name: Production
 on:
+  workflow_dispatch:
+
   schedule:
     # Weekly rebuild of all images, to pick up any upstream changes.
     - cron: "15 3 * * 0" # At 03:15 on Sunday
@@ -61,7 +63,7 @@ jobs:
       dev-versions: "exclude"
       matrix-versions: "exclude"
       # Push images only for merges into main and weekly schduled re-builds.
-      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 
   clean:
     name: Clean


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to production, development, and content workflows
- Update push conditions to push images when manually dispatched

Enables on-demand builds without waiting for scheduled runs.