### PR TITLE
Add update-helm job to production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -31,13 +31,14 @@ jobs:
     timeout-minutes: 10
     needs:
       - build
+      - update-helm
 
     steps:
       - uses: re-actors/alls-green@release/v1
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: clean
+          allowed-skips: clean, update-helm
       - if: always() && github.ref == 'refs/heads/main'
         continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
@@ -64,6 +65,46 @@ jobs:
       matrix-versions: "exclude"
       # Push images only for merges into main and weekly schduled re-builds.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+
+  update-helm:
+    name: Update Helm
+    if: ${{ needs.build.result == 'success' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install bakery
+        uses: posit-dev/images-shared/setup-bakery@main
+
+      - name: Get latest version
+        id: version
+        run: |
+          APP_VERSION=$(bakery get version connect)
+          APP_VERSION="${APP_VERSION%%[+-]*}"
+          echo "app-version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
+          private-key: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
+          owner: rstudio
+          repositories: helm
+
+      - name: Dispatch Helm update
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_VERSION: ${{ steps.version.outputs.app-version }}
+        run: |
+          gh workflow run product-release.yml \
+            --repo rstudio/helm \
+            --field product=connect \
+            --field version="$APP_VERSION"
 
   clean:
     name: Clean


### PR DESCRIPTION
## Summary

- Add `update-helm` job that dispatches `product-release.yml` in `rstudio/helm` after successful production builds
- Strips pre-release/build metadata from app version before dispatching
- Uses the `posit-connect-projects` GitHub App for the dispatch token (`POSIT_CONNECT_PROJECTS_APP_ID` / `POSIT_CONNECT_PROJECTS_PEM`)

## Dependencies

- rstudio/helm#830 — receiver `product-release.yml` workflow
- `posit-connect-projects` App must be installed on `rstudio/helm` with `actions: write` so the dispatch succeeds