### PR TITLE
Add Slack build notifications to CI workflows

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -31,6 +31,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: clean
       - if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
         with:
           result: ${{ steps.alls-green.outcome }}

--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -17,6 +17,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ci:
+    name: CI
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - build
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        id: alls-green
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: clean
+      - if: always() && github.ref == 'refs/heads/main'
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build:
     name: Build

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -39,6 +39,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: clean
       - if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
         with:
           result: ${{ steps.alls-green.outcome }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -34,9 +34,15 @@ jobs:
 
     steps:
       - uses: re-actors/alls-green@release/v1
+        id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: clean
+      - if: always() && github.ref == 'refs/heads/main'
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build:
     name: Build

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,6 +37,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: clean
       - if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
         with:
           result: ${{ steps.alls-green.outcome }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -32,9 +32,15 @@ jobs:
 
     steps:
       - uses: re-actors/alls-green@release/v1
+        id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: clean
+      - if: always() && github.ref == 'refs/heads/main'
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

- Add Slack notification step to CI meta-jobs in `development.yml` and `production.yml`
- Add CI meta-job (with alls-green + notification) to `content.yml`
- Uses the `slack-build-notify` composite action from posit-dev/images-shared#432

Notifications fire on state transitions only (passing->failing, failing->passing) and include failed job/step details with links.

### Temporary testing changes

- Action ref points at `worktree-slack-build-notify` branch (will revert to `@main` before merge)
- `refs/heads/main` guard relaxed for testing (marked with TODO comments)

### Required setup

- `SLACK_WEBHOOK_URL` repo secret pointing at `#platform-builds-images`

## Test plan

- [ ] Verify notification fires on PR build (guard relaxed)
- [ ] Verify message format in Slack
- [ ] Restore `@main` ref and `refs/heads/main` guard before merge