### PR TITLE
Scope clean jobs to match build version filters

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -70,6 +70,7 @@ jobs:
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
+      matrix-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
       remove-dangling-temporary-images: false

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -70,6 +70,7 @@ jobs:
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
+      dev-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
       remove-dangling-temporary-images: false


### PR DESCRIPTION
## Summary

- Development clean passes `dev-versions: "only"`
- Content clean passes `matrix-versions: "only"`
- Production clean uses defaults (exclude both)

Depends on posit-dev/images-shared#438

## Test plan

- [x] Development workflow cleanup removes dev image caches
- [x] Content workflow cleanup removes matrix image caches