### PR TITLE
Use non-API URL for TinyTeX cache busting

### DIFF
--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -76,6 +76,6 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -89,6 +89,6 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -76,6 +76,6 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -91,6 +91,6 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/template/Containerfile.ubuntu2204.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2204.jinja2
@@ -74,6 +74,6 @@ RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/template/Containerfile.ubuntu2404.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2404.jinja2
@@ -76,6 +76,6 @@ RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
     rm -f /tmp/tinytex-release.json

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
     ln -s /opt/quarto/1.4.557/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
     ln -s /opt/quarto/1.4.557/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
     ln -s /opt/quarto/1.4.557/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
     ln -s /opt/quarto/1.8.25/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
     ln -s /opt/quarto/1.8.25/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
     ln -s /opt/quarto/1.8.26/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
     ln -s /opt/quarto/1.8.26/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
     ln -s /opt/quarto/1.8.26/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
     ln -s /opt/quarto/1.8.27/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
     ln -s /opt/quarto/1.8.27/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
     ln -s /opt/quarto/1.8.27/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
     ln -s /opt/quarto/1.8.27/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -86,7 +86,7 @@ RUN mkdir -p /opt/quarto/1.9.36 && \
     ln -s /opt/quarto/1.9.36/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/quarto/1.9.36 && \
     ln -s /opt/quarto/1.9.36/bin/quarto /usr/local/bin/quarto 
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/template/Containerfile.ubuntu2204.jinja2
+++ b/connect/template/Containerfile.ubuntu2204.jinja2
@@ -74,7 +74,7 @@ RUN {% for quarto_version in Dependencies.quarto -%}
     {%- endfor %}
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {% for quarto_version in Dependencies.quarto -%}
     {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", loop.first) | indent(4) }} && \
     {%- endfor %}

--- a/connect/template/Containerfile.ubuntu2404.jinja2
+++ b/connect/template/Containerfile.ubuntu2404.jinja2
@@ -78,7 +78,7 @@ RUN {% for quarto_version in Dependencies.quarto -%}
     {%- endfor %}
 
 ### Install TinyTex ###
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
+ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {% for quarto_version in Dependencies.quarto -%}
     {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", loop.first) | indent(4) }} && \
     {%- endfor %}


### PR DESCRIPTION
## Summary

- The `ADD` instruction that busts the Docker cache for TinyTeX installs was hitting `api.github.com`, which is rate-limited at 60 req/hr per IP
- CI runners share IPs and hit this limit, causing 403 errors during builds
- Switch to the `github.com` HTML releases URL, which has much more generous rate limits and still changes content on each new TinyTeX release

Companion to posit-dev/images-workbench#71.

## Test plan

- [ ] CI builds complete without TinyTeX 403 errors