### PR TITLE
Remove unused download-pti justfile recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .dev-*
 tools/*goss
-tools/pti
 results/
 .bakery-bake.json
 .docker-bake.json

--- a/justfile
+++ b/justfile
@@ -1,7 +1,5 @@
 #!/usr/bin/env just --justfile
 
-GITHUB_TOKEN := `gh auth token`
-
 install-bakery *OPTS:
   #!/bin/bash
   # TODO: Update this after package is published somewhere
@@ -16,41 +14,3 @@ install-goss:
   chmod +rx {{justfile_directory()}}/tools/dgoss
 
 init: install-bakery install-goss
-
-download-pti:
-  #!/bin/bash
-  set -eo pipefail
-
-  RELEASE_API_ENDPOINT="/repos/posit-dev/pti/releases/latest"
-  GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token)}"
-
-  tag_name="$(gh --cache=1800s api $RELEASE_API_ENDPOINT --jq '.tag_name')"
-  release_version="${tag_name#v}"
-  assets="$(gh --cache=1800s api $RELEASE_API_ENDPOINT --jq '.assets.[] | [{name: .name, asset_url: .url}]')"
-
-  PROJECT_DIR="$(pwd)"
-  PTI_DST_DIR="$(pwd)/pti_${release_version}"
-  mkdir -p "${PTI_DST_DIR}"
-
-
-  echo "$assets" | jq -c '.[]' | while read -r asset; do
-      name=$(echo "$asset" | jq -r ".name")
-      asset_url=$(echo "$asset" | jq -r ".asset_url")
-
-      curl -sSL \
-          -H 'Accept: application/octet-stream' \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          "${asset_url}" \
-          -o "${PTI_DST_DIR}/${name}"
-  done
-
-  cd "${PTI_DST_DIR}"
-  shasum -c pti*checksums.txt
-  chmod +rx pti*linux_amd64
-
-  cd "$PROJECT_DIR"
-  TOOLS_DIR="${PROJECT_DIR}/tools"
-  mkdir -p "${TOOLS_DIR}"
-  mv "${PTI_DST_DIR}/pti_linux_amd64" "${TOOLS_DIR}/pti"
-  rm "${PTI_DST_DIR}/pti_checksums.txt"
-  rmdir "${PTI_DST_DIR}"


### PR DESCRIPTION
## Summary

- Delete the `download-pti` recipe in `justfile`. It's dead code: nothing else calls it, no CI workflow depends on it, git history last touched it during the 2025.01.0 build bring-up.
- Delete the top-level `GITHUB_TOKEN` assignment:

  ```just
  GITHUB_TOKEN := `gh auth token`
  ```

  It was only read inside `download-pti`, which already had its own `${GITHUB_TOKEN:-$(gh auth token)}` fallback.
- Drop `tools/pti` from `.gitignore` (only the `download-pti` recipe ever wrote to that path).

## Why

The top-level assignment runs `gh auth token` at justfile load time on every `just` invocation. That meant every recipe in this repo — even `install-goss`, which has nothing to do with GitHub — failed to parse unless `gh` was installed and authenticated. It's an implicit prerequisite not listed in the README.

After this change, `gh` is no longer required to run any justfile recipe.

## Test plan

- [x] `just --list` succeeds without `gh` installed/authenticated
- [x] `just install-goss` still works (unchanged)
- [x] `just install-bakery` still works (unchanged)