### PR TITLE
Install Quarto from the Posit Open apt repo

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -218,8 +218,7 @@ images:
     description: "Content execution images for Posit Connect with R, Python, Quarto,
       TinyTeX, system dependencies for popular R packages, and Posit Professional
       Drivers for database connectivity."
-    documentationUrl: 
-      https://docs.posit.co/connect/admin/runtimes/content-images/
+    documentationUrl: https://docs.posit.co/connect/admin/runtimes/content-images/
     buildSecrets:
       - id: github_token
         envVar: GITHUB_TOKEN

--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -69,14 +69,23 @@ COPY --from=python-builder /opt/python /opt/python
 RUN /opt/python/$PYTHON_VERSION/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=$QUARTO_VERSION && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
+#
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -82,14 +82,23 @@ COPY --from=python-builder /opt/python /opt/python
 RUN /opt/python/$PYTHON_VERSION/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=$QUARTO_VERSION && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
+#
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -69,14 +69,23 @@ COPY --from=python-builder /opt/python /opt/python
 RUN /opt/python/$PYTHON_VERSION/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=$QUARTO_VERSION && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
+#
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -84,14 +84,23 @@ COPY --from=python-builder /opt/python /opt/python
 RUN /opt/python/$PYTHON_VERSION/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=$QUARTO_VERSION && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
+#
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/test/goss.yaml
+++ b/connect-content/matrix/test/goss.yaml
@@ -7,6 +7,10 @@ package:
   {{end}}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "pro" }}true{{ else }}false{{ end }}
+  quarto:
+    installed: true
+    versions:
+      - {{ .Env.BUILD_ARG_QUARTO_VERSION }}
 
 file:
   python-{{ .Env.BUILD_ARG_PYTHON_VERSION }}:
@@ -15,9 +19,21 @@ file:
   r-{{ .Env.BUILD_ARG_R_VERSION }}:
     exists: true
     path: /opt/R/{{ .Env.BUILD_ARG_R_VERSION }}
-  quarto-{{ .Env.BUILD_ARG_QUARTO_VERSION }}:
+  quarto:
     exists: true
-    path: /opt/quarto/{{ .Env.BUILD_ARG_QUARTO_VERSION }}
+    path: /opt/quarto/bin/quarto
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
+  # users can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: true
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: true
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
 
 command:
   "Verify R installation is version {{ .Env.BUILD_ARG_R_VERSION }}":
@@ -37,7 +53,29 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+  "Verify TinyTeX is readable and executable by a non-root user":
+    # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install
+    # is accessible to non-root. `command -v` also forces PATH resolution,
+    # not just direct invocation — proves the /usr/local/bin symlinks are on
+    # the user's PATH. Guards against regressions in placement, permissions,
+    # or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+  "Verify quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
   "Verify R odbc package is installed":
     exec: /opt/R/{{ .Env.BUILD_ARG_R_VERSION }}/bin/R -e "library(odbc)"
     exit-status: 0

--- a/connect-content/template/Containerfile.ubuntu2204.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2204.jinja2
@@ -68,13 +68,14 @@ RUN {{ r.get_version_directory(r.build_arg()) }}/bin/R -e 'install.packages("odb
 RUN {{ python.get_version_directory(python.build_arg()) }}/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
-    {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }}
+RUN {{ quarto.install(quarto.build_arg()) | indent(4) }}
 
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
+#
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
+RUN {{ apt.install(packages="xz-utils") | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_directory() ~ "/bin/quarto", update_path=True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/template/Containerfile.ubuntu2404.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2404.jinja2
@@ -70,13 +70,14 @@ RUN {{ r.get_version_directory(r.build_arg()) }}/bin/R -e 'install.packages("odb
 RUN {{ python.get_version_directory(python.build_arg()) }}/bin/python -m pip install --no-cache-dir --break-system-packages --upgrade setuptools
 
 ### Install Quarto ###
-RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
-    {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }}
+RUN {{ quarto.install(quarto.build_arg()) | indent(4) }}
 
 ### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
+#
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
+RUN {{ apt.install(packages="xz-utils") | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_directory() ~ "/bin/quarto", update_path=True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/template/test/goss.yaml.jinja2
+++ b/connect-content/template/test/goss.yaml.jinja2
@@ -14,6 +14,10 @@ package:
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "pro" }}true{{ else }}false{{ end }}
   {%- endraw %}
+  quarto:
+    installed: true
+    versions:
+      - {{ goss.build_arg_env_var("QUARTO_VERSION") }}
 
 file:
   python-{{ goss.build_arg_env_var("PYTHON_VERSION") }}:
@@ -22,9 +26,21 @@ file:
   r-{{ goss.build_arg_env_var("R_VERSION") }}:
     exists: true
     path: {{ r.get_version_directory(goss.build_arg_env_var("R_VERSION")) }}
-  quarto-{{ goss.build_arg_env_var("QUARTO_VERSION") }}:
+  quarto:
     exists: true
-    path: {{ quarto.get_version_directory(goss.build_arg_env_var("QUARTO_VERSION")) }}
+    path: {{ quarto.get_directory() }}/bin/quarto
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
+  # users can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: true
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: true
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
 
 command:
   "Verify R installation is version {{ goss.build_arg_env_var("R_VERSION") }}":
@@ -44,7 +60,29 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+  "Verify TinyTeX is readable and executable by a non-root user":
+    # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install
+    # is accessible to non-root. `command -v` also forces PATH resolution,
+    # not just direct invocation — proves the /usr/local/bin symlinks are on
+    # the user's PATH. Guards against regressions in placement, permissions,
+    # or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+  "Verify quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
   "Verify R odbc package is installed":
     exec: {{ r.get_version_directory(goss.build_arg_env_var("R_VERSION")) }}/bin/R -e "library(odbc)"
     exit-status: 0

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -81,18 +81,23 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2025.11/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.8.26 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.26/quarto-1.8.26-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.26" --strip-components=1 && \
-    ln -s /opt/quarto/1.8.26/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.8.26 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
-
-### Install TensorFlow Serving ###
-COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 ### Create data volume ###
 VOLUME ["/data"]

--- a/connect/2025.11/scripts/install_connect.sh
+++ b/connect/2025.11/scripts/install_connect.sh
@@ -24,7 +24,7 @@ Executable = /opt/python/3.14.2/bin/python
 
 [Quarto]
 Enabled = true
-Executable = /opt/quarto/1.8.26/bin/quarto
+Executable = /opt/quarto/bin/quarto
 
 [TensorFlow]
 Enabled = true

--- a/connect/2025.11/test/goss.yaml
+++ b/connect/2025.11/test/goss.yaml
@@ -69,14 +69,26 @@ file:
     filetype: symlink
 
   # Check for Quarto installation
-  /opt/quarto/1.8.26/bin/quarto:
+  /opt/quarto/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     mode: "0755"
   /usr/local/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: symlink
-    linked-to: /opt/quarto/1.8.26/bin/quarto
-    mode: "0777"
+    linked-to: /opt/quarto/bin/quarto
+
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
+  # runtime user can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
 
 command:
   "Ensure Connect version is correct":
@@ -101,14 +113,12 @@ command:
       - "3.14.2"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
 
-
   "Ensure Quarto version is correct":
-    exec: /opt/quarto/1.8.26/bin/quarto --version
+    exec: /opt/quarto/bin/quarto --version
     exit-status: 0
     stdout:
       - "1.8.26"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-
   "Ensure Quarto symlink version is correct":
     exec: /usr/local/bin/quarto --version
     exit-status: 0
@@ -119,9 +129,37 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure Quarto symlink works":
+    exec: /usr/local/bin/quarto check --quiet
+    exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: "HOME='/opt' quarto list tools"
+    exec: quarto list tools
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
+    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
+    # forces PATH resolution, not just direct invocation — proves the
+    # /usr/local/bin symlinks are on the user's PATH. Guards against
+    # regressions in placement, permissions, or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -81,18 +81,23 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2025.12/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.8.26 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.26/quarto-1.8.26-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.26" --strip-components=1 && \
-    ln -s /opt/quarto/1.8.26/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.8.26 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
-
-### Install TensorFlow Serving ###
-COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 ### Create data volume ###
 VOLUME ["/data"]

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -52,12 +52,16 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        rstudio-drivers && \
-    apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        apt-get update -yqq && \
+        apt-get install -yqq --no-install-recommends \
+            rstudio-drivers && \
+        apt-get clean -yqq && \
+        rm -rf /var/lib/apt/lists/* && \
+        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
+    else \
+        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
+    fi
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
@@ -81,18 +85,23 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2025.12/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.8.26 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.26/quarto-1.8.26-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.26" --strip-components=1 && \
-    ln -s /opt/quarto/1.8.26/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.8.26 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
-
-### Install TensorFlow Serving ###
-COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 ### Create data volume ###
 VOLUME ["/data"]

--- a/connect/2025.12/scripts/install_connect.sh
+++ b/connect/2025.12/scripts/install_connect.sh
@@ -24,7 +24,7 @@ Executable = /opt/python/3.14.2/bin/python
 
 [Quarto]
 Enabled = true
-Executable = /opt/quarto/1.8.26/bin/quarto
+Executable = /opt/quarto/bin/quarto
 
 [TensorFlow]
 Enabled = true

--- a/connect/2025.12/test/goss.yaml
+++ b/connect/2025.12/test/goss.yaml
@@ -69,14 +69,26 @@ file:
     filetype: symlink
 
   # Check for Quarto installation
-  /opt/quarto/1.8.26/bin/quarto:
+  /opt/quarto/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     mode: "0755"
   /usr/local/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: symlink
-    linked-to: /opt/quarto/1.8.26/bin/quarto
-    mode: "0777"
+    linked-to: /opt/quarto/bin/quarto
+
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
+  # runtime user can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
 
 command:
   "Ensure Connect version is correct":
@@ -101,14 +113,12 @@ command:
       - "3.14.2"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
 
-
   "Ensure Quarto version is correct":
-    exec: /opt/quarto/1.8.26/bin/quarto --version
+    exec: /opt/quarto/bin/quarto --version
     exit-status: 0
     stdout:
       - "1.8.26"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-
   "Ensure Quarto symlink version is correct":
     exec: /usr/local/bin/quarto --version
     exit-status: 0
@@ -119,9 +129,37 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure Quarto symlink works":
+    exec: /usr/local/bin/quarto check --quiet
+    exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: "HOME='/opt' quarto list tools"
+    exec: quarto list tools
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
+    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
+    # forces PATH resolution, not just direct invocation — proves the
+    # /usr/local/bin symlinks are on the user's PATH. Guards against
+    # regressions in placement, permissions, or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -81,18 +81,23 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2026.01/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.8.27 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.27/quarto-1.8.27-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.27" --strip-components=1 && \
-    ln -s /opt/quarto/1.8.27/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.8.27 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
-
-### Install TensorFlow Serving ###
-COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 ### Create data volume ###
 VOLUME ["/data"]

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -52,12 +52,16 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        rstudio-drivers && \
-    apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        apt-get update -yqq && \
+        apt-get install -yqq --no-install-recommends \
+            rstudio-drivers && \
+        apt-get clean -yqq && \
+        rm -rf /var/lib/apt/lists/* && \
+        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
+    else \
+        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
+    fi
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
@@ -81,18 +85,23 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2026.01/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.8.27 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.27/quarto-1.8.27-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.27" --strip-components=1 && \
-    ln -s /opt/quarto/1.8.27/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.8.27 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
-
-### Install TensorFlow Serving ###
-COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 ### Create data volume ###
 VOLUME ["/data"]

--- a/connect/2026.01/scripts/install_connect.sh
+++ b/connect/2026.01/scripts/install_connect.sh
@@ -24,7 +24,7 @@ Executable = /opt/python/3.14.2/bin/python
 
 [Quarto]
 Enabled = true
-Executable = /opt/quarto/1.8.27/bin/quarto
+Executable = /opt/quarto/bin/quarto
 
 [TensorFlow]
 Enabled = true

--- a/connect/2026.01/test/goss.yaml
+++ b/connect/2026.01/test/goss.yaml
@@ -69,14 +69,26 @@ file:
     filetype: symlink
 
   # Check for Quarto installation
-  /opt/quarto/1.8.27/bin/quarto:
+  /opt/quarto/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     mode: "0755"
   /usr/local/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: symlink
-    linked-to: /opt/quarto/1.8.27/bin/quarto
-    mode: "0777"
+    linked-to: /opt/quarto/bin/quarto
+
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
+  # runtime user can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
 
 command:
   "Ensure Connect version is correct":
@@ -101,14 +113,12 @@ command:
       - "3.14.2"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
 
-
   "Ensure Quarto version is correct":
-    exec: /opt/quarto/1.8.27/bin/quarto --version
+    exec: /opt/quarto/bin/quarto --version
     exit-status: 0
     stdout:
       - "1.8.27"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-
   "Ensure Quarto symlink version is correct":
     exec: /usr/local/bin/quarto --version
     exit-status: 0
@@ -119,9 +129,37 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure Quarto symlink works":
+    exec: /usr/local/bin/quarto check --quiet
+    exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: "HOME='/opt' quarto list tools"
+    exec: quarto list tools
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
+    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
+    # forces PATH resolution, not just direct invocation — proves the
+    # /usr/local/bin symlinks are on the user's PATH. Guards against
+    # regressions in placement, permissions, or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -81,18 +81,23 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2026.02/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.8.27 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.27/quarto-1.8.27-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.27" --strip-components=1 && \
-    ln -s /opt/quarto/1.8.27/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.8.27 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
-
-### Install TensorFlow Serving ###
-COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 ### Create data volume ###
 VOLUME ["/data"]

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -52,12 +52,16 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        rstudio-drivers && \
-    apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        apt-get update -yqq && \
+        apt-get install -yqq --no-install-recommends \
+            rstudio-drivers && \
+        apt-get clean -yqq && \
+        rm -rf /var/lib/apt/lists/* && \
+        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
+    else \
+        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
+    fi
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
@@ -81,18 +85,23 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2026.02/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.8.27 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.8.27/quarto-1.8.27-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.8.27" --strip-components=1 && \
-    ln -s /opt/quarto/1.8.27/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.8.27 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
-
-### Install TensorFlow Serving ###
-COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 ### Create data volume ###
 VOLUME ["/data"]

--- a/connect/2026.02/scripts/install_connect.sh
+++ b/connect/2026.02/scripts/install_connect.sh
@@ -24,7 +24,7 @@ Executable = /opt/python/3.14.3/bin/python
 
 [Quarto]
 Enabled = true
-Executable = /opt/quarto/1.8.27/bin/quarto
+Executable = /opt/quarto/bin/quarto
 
 [TensorFlow]
 Enabled = true

--- a/connect/2026.02/test/goss.yaml
+++ b/connect/2026.02/test/goss.yaml
@@ -69,14 +69,26 @@ file:
     filetype: symlink
 
   # Check for Quarto installation
-  /opt/quarto/1.8.27/bin/quarto:
+  /opt/quarto/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     mode: "0755"
   /usr/local/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: symlink
-    linked-to: /opt/quarto/1.8.27/bin/quarto
-    mode: "0777"
+    linked-to: /opt/quarto/bin/quarto
+
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
+  # runtime user can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
 
 command:
   "Ensure Connect version is correct":
@@ -101,14 +113,12 @@ command:
       - "3.14.3"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
 
-
   "Ensure Quarto version is correct":
-    exec: /opt/quarto/1.8.27/bin/quarto --version
+    exec: /opt/quarto/bin/quarto --version
     exit-status: 0
     stdout:
       - "1.8.27"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-
   "Ensure Quarto symlink version is correct":
     exec: /usr/local/bin/quarto --version
     exit-status: 0
@@ -119,9 +129,37 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure Quarto symlink works":
+    exec: /usr/local/bin/quarto check --quiet
+    exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: "HOME='/opt' quarto list tools"
+    exec: quarto list tools
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
+    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
+    # forces PATH resolution, not just direct invocation — proves the
+    # /usr/local/bin symlinks are on the user's PATH. Guards against
+    # regressions in placement, permissions, or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -81,14 +81,22 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2026.03/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.9.36 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.9.36/quarto-1.9.36-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.9.36" --strip-components=1 && \
-    ln -s /opt/quarto/1.9.36/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.9.36 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -85,14 +85,22 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2026.03/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.9.36 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.9.36/quarto-1.9.36-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.9.36" --strip-components=1 && \
-    ln -s /opt/quarto/1.9.36/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.9.36 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/scripts/install_connect.sh
+++ b/connect/2026.03/scripts/install_connect.sh
@@ -24,7 +24,7 @@ Executable = /opt/python/3.14.3/bin/python
 
 [Quarto]
 Enabled = true
-Executable = /opt/quarto/1.9.36/bin/quarto
+Executable = /opt/quarto/bin/quarto
 
 [TensorFlow]
 Enabled = true

--- a/connect/2026.03/test/goss.yaml
+++ b/connect/2026.03/test/goss.yaml
@@ -69,14 +69,26 @@ file:
     filetype: symlink
 
   # Check for Quarto installation
-  /opt/quarto/1.9.36/bin/quarto:
+  /opt/quarto/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     mode: "0755"
   /usr/local/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: symlink
-    linked-to: /opt/quarto/1.9.36/bin/quarto
-    mode: "0777"
+    linked-to: /opt/quarto/bin/quarto
+
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
+  # runtime user can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
 
 command:
   "Ensure Connect version is correct":
@@ -101,14 +113,12 @@ command:
       - "3.14.3"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
 
-
   "Ensure Quarto version is correct":
-    exec: /opt/quarto/1.9.36/bin/quarto --version
+    exec: /opt/quarto/bin/quarto --version
     exit-status: 0
     stdout:
       - "1.9.36"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-
   "Ensure Quarto symlink version is correct":
     exec: /usr/local/bin/quarto --version
     exit-status: 0
@@ -119,9 +129,37 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure Quarto symlink works":
+    exec: /usr/local/bin/quarto check --quiet
+    exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: "HOME='/opt' quarto list tools"
+    exec: quarto list tools
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
+    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
+    # forces PATH resolution, not just direct invocation — proves the
+    # /usr/local/bin symlinks are on the user's PATH. Guards against
+    # regressions in placement, permissions, or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2026.04/Containerfile.ubuntu2204.std
+++ b/connect/2026.04/Containerfile.ubuntu2204.std
@@ -81,14 +81,22 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2026.04/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.9.37 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.9.37/quarto-1.9.37-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.9.37" --strip-components=1 && \
-    ln -s /opt/quarto/1.9.37/bin/quarto /usr/local/bin/quarto 
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.9.37 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.9.37/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.04/Containerfile.ubuntu2404.std
+++ b/connect/2026.04/Containerfile.ubuntu2404.std
@@ -85,14 +85,22 @@ RUN IMAGE_VARIANT="Standard" \
 COPY --chmod=0775 connect/2026.04/scripts/startup.sh /usr/local/bin/startup.sh
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/1.9.37 && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v1.9.37/quarto-1.9.37-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/1.9.37" --strip-components=1 && \
-    ln -s /opt/quarto/1.9.37/bin/quarto /usr/local/bin/quarto 
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=1.9.37 && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTex ###
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.9.37/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.04/scripts/install_connect.sh
+++ b/connect/2026.04/scripts/install_connect.sh
@@ -24,7 +24,7 @@ Executable = /opt/python/3.14.4/bin/python
 
 [Quarto]
 Enabled = true
-Executable = /opt/quarto/1.9.37/bin/quarto
+Executable = /opt/quarto/bin/quarto
 
 [TensorFlow]
 Enabled = true

--- a/connect/2026.04/test/goss.yaml
+++ b/connect/2026.04/test/goss.yaml
@@ -69,14 +69,26 @@ file:
     filetype: symlink
 
   # Check for Quarto installation
-  /opt/quarto/1.9.37/bin/quarto:
+  /opt/quarto/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     mode: "0755"
   /usr/local/bin/quarto:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: symlink
-    linked-to: /opt/quarto/1.9.37/bin/quarto
-    mode: "0777"
+    linked-to: /opt/quarto/bin/quarto
+
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
+  # runtime user can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
 
 command:
   "Ensure Connect version is correct":
@@ -101,14 +113,12 @@ command:
       - "3.14.4"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
 
-
   "Ensure Quarto version is correct":
-    exec: /opt/quarto/1.9.37/bin/quarto --version
+    exec: /opt/quarto/bin/quarto --version
     exit-status: 0
     stdout:
       - "1.9.37"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-
   "Ensure Quarto symlink version is correct":
     exec: /usr/local/bin/quarto --version
     exit-status: 0
@@ -119,9 +129,37 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure Quarto symlink works":
+    exec: /usr/local/bin/quarto check --quiet
+    exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: "HOME='/opt' quarto list tools"
+    exec: quarto list tools
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
+    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
+    # forces PATH resolution, not just direct invocation — proves the
+    # /usr/local/bin symlinks are on the user's PATH. Guards against
+    # regressions in placement, permissions, or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/template/Containerfile.ubuntu2204.jinja2
+++ b/connect/template/Containerfile.ubuntu2204.jinja2
@@ -67,21 +67,15 @@ RUN IMAGE_VARIANT="{{ Image.Variant }}" {% if Image.DownloadURL is defined %}DOW
 COPY --chmod=0775 {{ Path.Version }}/scripts/startup.sh /usr/local/bin/startup.sh
 
 {% if Image.Variant != "Minimal" -%}
+{%- set quarto_version = Dependencies.quarto[0] -%}
 ### Install Quarto ###
-RUN {% for quarto_version in Dependencies.quarto -%}
-    {{ quarto.install(quarto_version) | indent(4) }} && \
-    {% if loop.first -%}{{ quarto.symlink_binary(quarto_version, "quarto", "/usr/local/bin/quarto") }}{% endif %} {% if not loop.last %}&& \{% endif %}
-    {%- endfor %}
+RUN {{ quarto.install(quarto_version) | indent(4) }}
 
 ### Install TinyTex ###
-{% if Dependencies.quarto is sequence and Dependencies.quarto is not string -%}
-{% set quarto_version = Dependencies.quarto.0 -%}
-{% else -%}
-{% set quarto_version = Dependencies.quarto -%}
-{% endif -%}
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
+RUN {{ apt.install(packages="xz-utils") | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_directory() ~ "/bin/quarto", update_path=True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 {% endif -%}

--- a/connect/template/Containerfile.ubuntu2404.jinja2
+++ b/connect/template/Containerfile.ubuntu2404.jinja2
@@ -71,21 +71,15 @@ RUN IMAGE_VARIANT="{{ Image.Variant }}" {% if Image.DownloadURL is defined %}DOW
 COPY --chmod=0775 {{ Path.Version }}/scripts/startup.sh /usr/local/bin/startup.sh
 
 {% if Image.Variant != "Minimal" -%}
+{%- set quarto_version = Dependencies.quarto[0] -%}
 ### Install Quarto ###
-RUN {% for quarto_version in Dependencies.quarto -%}
-    {{ quarto.install(quarto_version) | indent(4) }} && \
-    {% if loop.first -%}{{ quarto.symlink_binary(quarto_version, "quarto", "/usr/local/bin/quarto") }}{% endif %} {% if not loop.last %}&& \{% endif %}
-    {%- endfor %}
+RUN {{ quarto.install(quarto_version) | indent(4) }}
 
 ### Install TinyTex ###
-{% if Dependencies.quarto is sequence and Dependencies.quarto is not string -%}
-{% set quarto_version = Dependencies.quarto.0 -%}
-{% else -%}
-{% set quarto_version = Dependencies.quarto -%}
-{% endif -%}
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
+RUN {{ apt.install(packages="xz-utils") | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_directory() ~ "/bin/quarto", update_path=True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 {% endif -%}

--- a/connect/template/scripts/install_connect.sh.jinja2
+++ b/connect/template/scripts/install_connect.sh.jinja2
@@ -47,9 +47,7 @@ Executable = {{ python.get_version_directory(python_version) }}/bin/python
 
 [Quarto]
 Enabled = true
-{% for quarto_version in Dependencies.quarto -%}
-Executable = {{ quarto.get_version_directory(quarto_version) }}/bin/quarto
-{%- endfor %}
+Executable = {{ quarto.get_directory() }}/bin/quarto
 
 [TensorFlow]
 Enabled = true

--- a/connect/template/test/goss.yaml.jinja2
+++ b/connect/template/test/goss.yaml.jinja2
@@ -87,16 +87,26 @@ file:
   {%- endfor %}
 
   # Check for Quarto installation
-  {% for quarto_version in Dependencies.quarto -%}
-  /opt/quarto/{{ quarto_version }}/bin/quarto:
+  {{ quarto.get_directory() }}/bin/quarto:
     exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
     mode: "0755"
   /usr/local/bin/quarto:
     exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
     filetype: symlink
-    linked-to: /opt/quarto/{{ quarto_version }}/bin/quarto
-    mode: "0777"
-  {%- endfor %}
+    linked-to: {{ quarto.get_directory() }}/bin/quarto
+
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
+  # runtime user can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
+    filetype: symlink
 
 command:
   "Ensure Connect version is correct":
@@ -105,14 +115,14 @@ command:
     stdout:
       - "{{ Image.Version }}"
 
-{% for r_version in Dependencies.R %}
+  {% for r_version in Dependencies.R %}
   "Ensure R version is correct":
     exec: {{ r.get_version_directory(r_version) }}/bin/R --version
     exit-status: 0
     stdout:
       - "{{ r_version }}"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
-{% endfor %}
+  {% endfor %}
 
   {% for python_version in Dependencies.python -%}
   "Ensure Python {{ python_version }} version is correct":
@@ -123,14 +133,12 @@ command:
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   {%- endfor %}
 
-{% for quarto_version in Dependencies.quarto %}
   "Ensure Quarto version is correct":
-    exec: {{ quarto.get_version_directory(quarto_version) }}/bin/quarto --version
+    exec: {{ quarto.get_directory() }}/bin/quarto --version
     exit-status: 0
     stdout:
-      - "{{ quarto_version }}"
+      - "{{ Dependencies.quarto.0 }}"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
-{% endfor %}
   "Ensure Quarto symlink version is correct":
     exec: /usr/local/bin/quarto --version
     exit-status: 0
@@ -141,9 +149,37 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
+  "Ensure Quarto symlink works":
+    exec: /usr/local/bin/quarto check --quiet
+    exit-status: 0
+    skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   "Ensure TinyTeX is installed":
-    exec: "HOME='/opt' quarto list tools"
+    exec: quarto list tools
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
+    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
+    # forces PATH resolution, not just direct invocation — proves the
+    # /usr/local/bin symlinks are on the user's PATH. Guards against
+    # regressions in placement, permissions, or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
+  "Ensure quarto package is held":
+    # Guards against apt upgrade inside the container drifting quarto off
+    # the pinned version the image is labeled with.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}


### PR DESCRIPTION
## Summary

Switch Connect and Connect Content to install Quarto via `apt-get install quarto={version}` from the [Posit Open apt repository](https://dl.posit.co/public/open/), using the updated `quarto.install()` macro from posit-dev/images-shared.

**Requires posit-dev/images-shared#479.**

## Why

- Avoids `${TARGETARCH}` URL construction. Posit publishes `quarto` as a multi-arch deb (amd64 + arm64) on both `jammy` and `noble`.
- dpkg owns the install, so goss `package.quarto.versions` assertions work directly without path-based proxies.
- No tarball extraction.

## Changes

The `quarto` deb installs to a flat `/opt/quarto/` directory (binary at `/opt/quarto/bin/quarto`) and symlinks `/usr/local/bin/quarto` via its postinst script. Downstream consequences in this repo:

- **Flatten the vestigial `{% for quarto_version in Dependencies.quarto %}` loop** in `connect/template/Containerfile.ubuntu*.jinja2`, `scripts/install_connect.sh.jinja2`, and `test/goss.yaml.jinja2`. Every Connect image has always shipped exactly one Quarto, so the loop is unused in practice. (Apt also does not support installing multiple versions into the same prefix.)
- **Drop the redundant `quarto.symlink_binary(...)` call** in connect-content templates — the deb's postinst already creates the `/usr/local/bin/quarto` symlink.
- **Install `xz-utils` explicitly** in the TinyTeX RUN; it is needed to unpack the TinyTeX `.tar.xz` archive and was previously pulled in transitively by the tarball install path.
- **Update path references** in `install_connect.sh.jinja2` and goss templates from `/opt/quarto/{version}/bin/quarto` to `/opt/quarto/bin/quarto`. Add a `package.quarto.versions` goss check in connect-content (now possible because the install is dpkg-tracked).

### Scope

Only the quarto install blocks and their direct consumers (goss path checks, `install_connect.sh` Rscript runner config) are touched in the rendered Containerfiles. Rerendering via `bakery update files` would also pick up unrelated drift (e.g., TensorFlow Serving removal, TARGETARCH additions in `connect-content-init`); those hunks are intentionally out of scope here and can be handled in a separate cleanup PR.

## Test plan

- [x] `docker buildx build -f connect/2026.03/Containerfile.ubuntu2204.std .` succeeds
- [x] Built image: `quarto --version` → `1.9.36`; `/opt/quarto/bin/quarto` and `/usr/local/bin/quarto` symlink both present; `dpkg -s quarto` reports version 1.9.36
- [ ] CI builds both Standard and Minimal variants across all Connect versions
- [ ] CI builds connect-content matrix (Ubuntu 22.04 / 24.04 × base / pro)
- [ ] goss tests pass for all variants