### PR TITLE
Mount `GITHUB_TOKEN` as secret to prevent ratelimiting on TinyTeX install

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -57,6 +57,7 @@ jobs:
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
     with:
+      version: "feature/quarto-tinytex-build-secret"
       matrix-versions: "only"
       # Push images only for merges into main and weekly scheduled re-builds.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -57,7 +57,6 @@ jobs:
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
     with:
-      version: "feature/quarto-tinytex-build-secret"
       matrix-versions: "only"
       # Push images only for merges into main and weekly scheduled re-builds.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -54,6 +54,7 @@ jobs:
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     with:
+      version: "feature/quarto-tinytex-build-secret"
       dev-versions: "only"
       matrix-versions: "exclude"
       # Push images only for merges into main and daily schduled re-builds.

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -54,7 +54,6 @@ jobs:
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     with:
-      version: "feature/quarto-tinytex-build-secret"
       dev-versions: "only"
       matrix-versions: "exclude"
       # Push images only for merges into main and daily schduled re-builds.

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -60,6 +60,7 @@ jobs:
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
     with:
+      version: "feature/quarto-tinytex-build-secret"
       dev-versions: "exclude"
       matrix-versions: "exclude"
       # Push images only for merges into main and weekly schduled re-builds.

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -60,7 +60,6 @@ jobs:
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
     with:
-      version: "feature/quarto-tinytex-build-secret"
       dev-versions: "exclude"
       matrix-versions: "exclude"
       # Push images only for merges into main and weekly schduled re-builds.

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -29,6 +29,10 @@ images:
     description: "A containerized image of Posit Connect (PCT), which organizes and
       centralizes data science packages across your team, department, or the entire
       organization."
+    documentationUrl: https://docs.posit.co/connect/
+    buildSecrets:
+      - id: github_token
+        envVar: GITHUB_TOKEN
     dependencyConstraints:
       - dependency: R
         constraint:
@@ -39,7 +43,6 @@ images:
       - dependency: quarto
         constraint:
           latest: true
-    documentationUrl: https://docs.posit.co/connect/
     variants:
       - name: Standard
         extension: std
@@ -204,6 +207,9 @@ images:
       Drivers for database connectivity."
     documentationUrl: 
       https://docs.posit.co/connect/admin/runtimes/content-images/
+    buildSecrets:
+      - id: github_token
+        envVar: GITHUB_TOKEN
     variants:
       - name: base
         extension: base

--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -77,5 +77,7 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -79,5 +79,5 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -78,6 +78,5 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -91,6 +91,5 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -92,5 +92,5 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -90,5 +90,7 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -77,5 +77,7 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -79,5 +79,5 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -78,6 +78,5 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -93,6 +93,5 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -94,5 +94,5 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -92,5 +92,7 @@ RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/test/goss.yaml
+++ b/connect-content/matrix/test/goss.yaml
@@ -34,7 +34,7 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
   "Verify Quarto has TinyTeX installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect-content/template/Containerfile.ubuntu2204.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2204.jinja2
@@ -75,5 +75,6 @@ RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
+RUN {{ quarto.github_token_secret_mount() }} \
+    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/template/Containerfile.ubuntu2204.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2204.jinja2
@@ -76,5 +76,5 @@ RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/template/Containerfile.ubuntu2404.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2404.jinja2
@@ -78,5 +78,5 @@ RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/template/Containerfile.ubuntu2404.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2404.jinja2
@@ -77,5 +77,6 @@ RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
 # Caches won't invalidate correctly on new releases for TinyTeX installs.
 # This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
+RUN {{ quarto.github_token_secret_mount() }} \
+    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/template/test/goss.yaml.jinja2
+++ b/connect-content/template/test/goss.yaml.jinja2
@@ -41,7 +41,7 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
   "Verify Quarto has TinyTeX installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.05/test/goss.yaml
+++ b/connect/2025.05/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.06/test/goss.yaml
+++ b/connect/2025.06/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.07/test/goss.yaml
+++ b/connect/2025.07/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.09/test/goss.yaml
+++ b/connect/2025.09/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.10/test/goss.yaml
+++ b/connect/2025.10/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.11/test/goss.yaml
+++ b/connect/2025.11/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.26 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.26/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.12/test/goss.yaml
+++ b/connect/2025.12/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.01/test/goss.yaml
+++ b/connect/2026.01/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.8.27 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.27/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2026.02/test/goss.yaml
+++ b/connect/2026.02/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -87,7 +87,9 @@ RUN mkdir -p /opt/quarto/1.9.36 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -88,8 +88,7 @@ RUN mkdir -p /opt/quarto/1.9.36 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -89,7 +89,7 @@ RUN mkdir -p /opt/quarto/1.9.36 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -93,7 +93,7 @@ RUN mkdir -p /opt/quarto/1.9.36 && \
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    HOME="/opt" /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -92,8 +92,7 @@ RUN mkdir -p /opt/quarto/1.9.36 && \
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
-    HOME="/opt" /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -91,7 +91,9 @@ RUN mkdir -p /opt/quarto/1.9.36 && \
 
 ### Install TinyTex ###
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN --mount=type=secret,id=github_token,required=false \
+    if [ -s /run/secrets/github_token ]; then export GH_TOKEN="$(cat /run/secrets/github_token)"; fi && \
+    /opt/quarto/1.9.36/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/test/goss.yaml
+++ b/connect/2026.03/test/goss.yaml
@@ -119,12 +119,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"

--- a/connect/template/Containerfile.ubuntu2204.jinja2
+++ b/connect/template/Containerfile.ubuntu2204.jinja2
@@ -74,10 +74,14 @@ RUN {% for quarto_version in Dependencies.quarto -%}
     {%- endfor %}
 
 ### Install TinyTex ###
+{% if Dependencies.quarto is sequence and Dependencies.quarto is not string -%}
+{% set quarto_version = Dependencies.quarto.0 -%}
+{% else -%}
+{% set quarto_version = Dependencies.quarto -%}
+{% endif -%}
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {% for quarto_version in Dependencies.quarto -%}
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", loop.first) | indent(4) }} && \
-    {%- endfor %}
+RUN {{ quarto.github_token_secret_mount() }} \
+    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", True) | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 {% endif -%}

--- a/connect/template/Containerfile.ubuntu2204.jinja2
+++ b/connect/template/Containerfile.ubuntu2204.jinja2
@@ -81,7 +81,7 @@ RUN {% for quarto_version in Dependencies.quarto -%}
 {% endif -%}
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", True) | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 {% endif -%}

--- a/connect/template/Containerfile.ubuntu2404.jinja2
+++ b/connect/template/Containerfile.ubuntu2404.jinja2
@@ -85,7 +85,7 @@ RUN {% for quarto_version in Dependencies.quarto -%}
 {% endif -%}
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", True) | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 {% endif -%}

--- a/connect/template/Containerfile.ubuntu2404.jinja2
+++ b/connect/template/Containerfile.ubuntu2404.jinja2
@@ -78,10 +78,14 @@ RUN {% for quarto_version in Dependencies.quarto -%}
     {%- endfor %}
 
 ### Install TinyTex ###
+{% if Dependencies.quarto is sequence and Dependencies.quarto is not string -%}
+{% set quarto_version = Dependencies.quarto.0 -%}
+{% else -%}
+{% set quarto_version = Dependencies.quarto -%}
+{% endif -%}
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {% for quarto_version in Dependencies.quarto -%}
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", loop.first) | indent(4) }} && \
-    {%- endfor %}
+RUN {{ quarto.github_token_secret_mount() }} \
+    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto_version | trim) + "/bin/quarto", True) | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 {% endif -%}

--- a/connect/template/test/goss.yaml.jinja2
+++ b/connect/template/test/goss.yaml.jinja2
@@ -141,12 +141,8 @@ command:
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
-    skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"


### PR DESCRIPTION
Depends on https://github.com/posit-dev/images-shared/pull/487

- Define `GITHUB_TOKEN` as a build secret for connect and connect-content images
- Update TinyTeX installs to mount `GITHUB_TOKEN` as `GH_TOKEN` (the env var Quarto will use for GitHub API requests)
- Install TinyTeX to /opt