### PR TITLE
Install pro-drivers on all architectures

### DIFF
--- a/connect-content/README.md
+++ b/connect-content/README.md
@@ -24,9 +24,6 @@ See the [repository README](https://github.com/posit-dev/images-connect#deployin
 | Base | (none) | Open-source R and Python |
 | Pro | `-pro` | Includes Posit Professional Drivers for database connectivity |
 
-> [!WARNING]
-> Pro image builds for linux/arm64 do not include the Pro Drivers due to platform support limitations.
-
 ## Image Tags
 
 Images are published to:

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -55,14 +55,12 @@ RUN apt-get update -yqq && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 
-### Install Pro Drivers and ODBC ###
+### Install Pro Drivers ###
 RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
-
-### Configure ODBC drivers ###
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -55,17 +55,13 @@ RUN apt-get update -yqq && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 
-### Install Pro Drivers and ODBC ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+### Install Pro Drivers ###
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN apt-get update -yqq && \

--- a/connect-content/template/Containerfile.ubuntu2204.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2204.jinja2
@@ -42,10 +42,8 @@ COPY {{ Path.Version }}/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_package
 {{ apt.run_install(files = '/tmp/ubuntu-22.04_packages.txt') }}
 
 {% if Image.Variant == "pro" -%}
-### Install Pro Drivers and ODBC ###
+### Install Pro Drivers ###
 {{ apt.run_install(packages="rstudio-drivers") }}
-
-### Configure ODBC drivers ###
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 {% endif -%}

--- a/connect-content/template/Containerfile.ubuntu2404.jinja2
+++ b/connect-content/template/Containerfile.ubuntu2404.jinja2
@@ -42,13 +42,9 @@ COPY {{ Path.Version }}/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_package
 {{ apt.run_install(files = '/tmp/ubuntu-24.04_packages.txt') }}
 
 {% if Image.Variant == "pro" -%}
-### Install Pro Drivers and ODBC ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        {{ apt.install(packages="rstudio-drivers") | indent(8) }} && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+### Install Pro Drivers ###
+{{ apt.run_install(packages="rstudio-drivers") }}
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 {% endif -%}
 

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.4.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2025.05/test/goss.yaml
+++ b/connect/2025.05/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -124,4 +126,10 @@ command:
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.4.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2025.06/test/goss.yaml
+++ b/connect/2025.06/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -124,4 +126,10 @@ command:
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.4.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2025.07/test/goss.yaml
+++ b/connect/2025.07/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -124,4 +126,10 @@ command:
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.1 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2025.09/test/goss.yaml
+++ b/connect/2025.09/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -124,4 +126,10 @@ command:
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.1 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2025.10/test/goss.yaml
+++ b/connect/2025.10/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -124,4 +126,10 @@ command:
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2025.11/test/goss.yaml
+++ b/connect/2025.11/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -132,7 +134,6 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
@@ -154,6 +155,12 @@ command:
     stdout:
       - "tlmgr"
       - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
     # Guards against apt upgrade inside the container drifting quarto off

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -52,16 +52,12 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2025.12/test/goss.yaml
+++ b/connect/2025.12/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -132,7 +134,6 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
@@ -154,6 +155,12 @@ command:
     stdout:
       - "tlmgr"
       - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
     # Guards against apt upgrade inside the container drifting quarto off

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -52,16 +52,12 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2026.01/test/goss.yaml
+++ b/connect/2026.01/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -132,7 +134,6 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
@@ -154,6 +155,12 @@ command:
     stdout:
       - "tlmgr"
       - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
     # Guards against apt upgrade inside the container drifting quarto off

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -52,16 +52,12 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.2 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2026.02/test/goss.yaml
+++ b/connect/2026.02/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -132,7 +134,6 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
@@ -154,6 +155,12 @@ command:
     stdout:
       - "tlmgr"
       - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
     # Guards against apt upgrade inside the container drifting quarto off

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -52,16 +52,12 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.5.3 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2026.03/test/goss.yaml
+++ b/connect/2026.03/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -132,7 +134,6 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
@@ -154,6 +155,12 @@ command:
     stdout:
       - "tlmgr"
       - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
     # Guards against apt upgrade inside the container drifting quarto off

--- a/connect/2026.04/Containerfile.ubuntu2204.std
+++ b/connect/2026.04/Containerfile.ubuntu2204.std
@@ -56,8 +56,8 @@ RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2026.04/Containerfile.ubuntu2404.std
+++ b/connect/2026.04/Containerfile.ubuntu2404.std
@@ -52,16 +52,12 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \

--- a/connect/2026.04/test/goss.yaml
+++ b/connect/2026.04/test/goss.yaml
@@ -18,6 +18,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 
 process:
   connect:
@@ -132,7 +134,6 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
@@ -154,6 +155,12 @@ command:
     stdout:
       - "tlmgr"
       - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
     # Guards against apt upgrade inside the container drifting quarto off

--- a/connect/README.md
+++ b/connect/README.md
@@ -50,9 +50,6 @@ Two variants are available:
 
 See [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending) for how to build on the Minimal image.
 
-> [!WARNING]
-> Standard image builds for linux/arm64 do not include the Pro Drivers due to platform support limitations.
-
 ## Image Tags
 
 Images are published to:

--- a/connect/template/Containerfile.ubuntu2204.jinja2
+++ b/connect/template/Containerfile.ubuntu2204.jinja2
@@ -44,8 +44,8 @@ COPY {{ Path.Version }}/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_package
 
 {% if Image.Variant != "Minimal" -%}
 ### Install Pro Drivers ###
-RUN {{ apt.install(packages="rstudio-drivers") | indent(4) }} && \
-    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+{{ apt.run_install(packages="rstudio-drivers") }}
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 {{ r.run_install(Dependencies.R) }}

--- a/connect/template/Containerfile.ubuntu2404.jinja2
+++ b/connect/template/Containerfile.ubuntu2404.jinja2
@@ -44,12 +44,8 @@ COPY {{ Path.Version }}/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_package
 
 {% if Image.Variant != "Minimal" -%}
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        {{ apt.install(packages="rstudio-drivers") | indent(8) }} && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+{{ apt.run_install(packages="rstudio-drivers") }}
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Install R ###
 {{ r.run_install(Dependencies.R) }}

--- a/connect/template/test/goss.yaml.jinja2
+++ b/connect/template/test/goss.yaml.jinja2
@@ -31,6 +31,8 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  rstudio-drivers:
+    installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
   {%- endraw %}
 
 process:
@@ -162,6 +164,12 @@ command:
       # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
       # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
       - "/tinytex\\s+External Installation/"
+    skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
+  "Verify ODBC drivers are configured":
+    exec: cat /etc/odbcinst.ini
+    exit-status: 0
+    stdout:
+      - "/PostgreSQL|MySQL|SQLServer/"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   "Ensure TinyTeX is readable and executable by rstudio-connect":
     # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm


### PR DESCRIPTION
## Summary

- Remove the `TARGETARCH` conditional that skipped `rstudio-drivers` installation on non-amd64
- Use `apt.run_install()` consistently for driver installation across all templates
- Remove ARM64 limitation warnings from READMEs
- Add goss coverage for `rstudio-drivers` package and ODBC configuration on the connect image

The `rstudio-drivers` package is now available on Cloudsmith for ARM, so the arch-gating introduced in 5ae41d0 is no longer needed.

Closes https://github.com/posit-dev/images-connect/issues/426