### PR TITLE
Trim verbose goss test comments

### DIFF
--- a/connect-content/matrix/test/goss.yaml
+++ b/connect-content/matrix/test/goss.yaml
@@ -22,9 +22,7 @@ file:
   quarto:
     exists: true
     path: /opt/quarto/bin/quarto
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
-  # users can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: true
     filetype: directory
@@ -53,25 +51,17 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
   "Verify TinyTeX is readable and executable by a non-root user":
-    # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install
-    # is accessible to non-root. `command -v` also forces PATH resolution,
-    # not just direct invocation — proves the /usr/local/bin symlinks are on
-    # the user's PATH. Guards against regressions in placement, permissions,
-    # or PATH setup.
     exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
     exit-status: 0
     stdout:
       - "tlmgr"
       - "pdfTeX"
   "Verify quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:

--- a/connect-content/template/test/goss.yaml.jinja2
+++ b/connect-content/template/test/goss.yaml.jinja2
@@ -29,9 +29,7 @@ file:
   quarto:
     exists: true
     path: {{ quarto.get_directory() }}/bin/quarto
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
-  # users can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: true
     filetype: directory
@@ -60,25 +58,17 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
   "Verify TinyTeX is readable and executable by a non-root user":
-    # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install
-    # is accessible to non-root. `command -v` also forces PATH resolution,
-    # not just direct invocation — proves the /usr/local/bin symlinks are on
-    # the user's PATH. Guards against regressions in placement, permissions,
-    # or PATH setup.
     exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
     exit-status: 0
     stdout:
       - "tlmgr"
       - "pdfTeX"
   "Verify quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:

--- a/connect/2025.11/test/goss.yaml
+++ b/connect/2025.11/test/goss.yaml
@@ -79,9 +79,7 @@ file:
     filetype: symlink
     linked-to: /opt/quarto/bin/quarto
 
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
-  # runtime user can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: directory
@@ -134,27 +132,14 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure TinyTeX is readable and executable by rstudio-connect":
-    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
-    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
-    # forces PATH resolution, not just direct invocation — proves the
-    # /usr/local/bin symlinks are on the user's PATH. Guards against
-    # regressions in placement, permissions, or PATH setup.
-    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
-    exit-status: 0
-    stdout:
-      - "tlmgr"
-      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify ODBC drivers are configured":
     exec: cat /etc/odbcinst.ini
@@ -162,9 +147,15 @@ command:
     stdout:
       - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:

--- a/connect/2025.12/test/goss.yaml
+++ b/connect/2025.12/test/goss.yaml
@@ -79,9 +79,7 @@ file:
     filetype: symlink
     linked-to: /opt/quarto/bin/quarto
 
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
-  # runtime user can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: directory
@@ -134,27 +132,14 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure TinyTeX is readable and executable by rstudio-connect":
-    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
-    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
-    # forces PATH resolution, not just direct invocation — proves the
-    # /usr/local/bin symlinks are on the user's PATH. Guards against
-    # regressions in placement, permissions, or PATH setup.
-    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
-    exit-status: 0
-    stdout:
-      - "tlmgr"
-      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify ODBC drivers are configured":
     exec: cat /etc/odbcinst.ini
@@ -162,9 +147,15 @@ command:
     stdout:
       - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:

--- a/connect/2026.01/test/goss.yaml
+++ b/connect/2026.01/test/goss.yaml
@@ -79,9 +79,7 @@ file:
     filetype: symlink
     linked-to: /opt/quarto/bin/quarto
 
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
-  # runtime user can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: directory
@@ -134,27 +132,14 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure TinyTeX is readable and executable by rstudio-connect":
-    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
-    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
-    # forces PATH resolution, not just direct invocation — proves the
-    # /usr/local/bin symlinks are on the user's PATH. Guards against
-    # regressions in placement, permissions, or PATH setup.
-    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
-    exit-status: 0
-    stdout:
-      - "tlmgr"
-      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify ODBC drivers are configured":
     exec: cat /etc/odbcinst.ini
@@ -162,9 +147,15 @@ command:
     stdout:
       - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:

--- a/connect/2026.02/test/goss.yaml
+++ b/connect/2026.02/test/goss.yaml
@@ -79,9 +79,7 @@ file:
     filetype: symlink
     linked-to: /opt/quarto/bin/quarto
 
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
-  # runtime user can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: directory
@@ -134,27 +132,14 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure TinyTeX is readable and executable by rstudio-connect":
-    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
-    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
-    # forces PATH resolution, not just direct invocation — proves the
-    # /usr/local/bin symlinks are on the user's PATH. Guards against
-    # regressions in placement, permissions, or PATH setup.
-    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
-    exit-status: 0
-    stdout:
-      - "tlmgr"
-      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify ODBC drivers are configured":
     exec: cat /etc/odbcinst.ini
@@ -162,9 +147,15 @@ command:
     stdout:
       - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:

--- a/connect/2026.03/test/goss.yaml
+++ b/connect/2026.03/test/goss.yaml
@@ -79,9 +79,7 @@ file:
     filetype: symlink
     linked-to: /opt/quarto/bin/quarto
 
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
-  # runtime user can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: directory
@@ -134,27 +132,14 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure TinyTeX is readable and executable by rstudio-connect":
-    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
-    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
-    # forces PATH resolution, not just direct invocation — proves the
-    # /usr/local/bin symlinks are on the user's PATH. Guards against
-    # regressions in placement, permissions, or PATH setup.
-    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
-    exit-status: 0
-    stdout:
-      - "tlmgr"
-      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify ODBC drivers are configured":
     exec: cat /etc/odbcinst.ini
@@ -162,9 +147,15 @@ command:
     stdout:
       - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:

--- a/connect/2026.04/test/goss.yaml
+++ b/connect/2026.04/test/goss.yaml
@@ -79,9 +79,7 @@ file:
     filetype: symlink
     linked-to: /opt/quarto/bin/quarto
 
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
-  # runtime user can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
     filetype: directory
@@ -134,27 +132,14 @@ command:
   "Ensure Quarto symlink works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure TinyTeX is readable and executable by rstudio-connect":
-    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
-    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
-    # forces PATH resolution, not just direct invocation — proves the
-    # /usr/local/bin symlinks are on the user's PATH. Guards against
-    # regressions in placement, permissions, or PATH setup.
-    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
-    exit-status: 0
-    stdout:
-      - "tlmgr"
-      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify ODBC drivers are configured":
     exec: cat /etc/odbcinst.ini
@@ -162,9 +147,15 @@ command:
     stdout:
       - "/PostgreSQL|MySQL|SQLServer/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Ensure TinyTeX is readable and executable by rstudio-connect":
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:

--- a/connect/template/test/goss.yaml.jinja2
+++ b/connect/template/test/goss.yaml.jinja2
@@ -97,9 +97,7 @@ file:
     filetype: symlink
     linked-to: {{ quarto.get_directory() }}/bin/quarto
 
-  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so the rstudio-connect
-  # runtime user can read the install; tlmgr path add symlinks the binaries into
-  # /usr/local/bin so they are on PATH.
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
   /opt/.TinyTeX:
     exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
     filetype: directory
@@ -159,10 +157,8 @@ command:
     exec: quarto list tools
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
       - "/tinytex\\s+External Installation/"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   "Verify ODBC drivers are configured":
@@ -172,11 +168,6 @@ command:
       - "/PostgreSQL|MySQL|SQLServer/"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   "Ensure TinyTeX is readable and executable by rstudio-connect":
-    # Runs tlmgr and pdflatex as the rstudio-connect runtime user to confirm
-    # the /opt/.TinyTeX install is accessible to non-root. `command -v` also
-    # forces PATH resolution, not just direct invocation — proves the
-    # /usr/local/bin symlinks are on the user's PATH. Guards against
-    # regressions in placement, permissions, or PATH setup.
     exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' rstudio-connect
     exit-status: 0
     stdout:
@@ -184,8 +175,7 @@ command:
       - "pdfTeX"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   "Ensure quarto package is held":
-    # Guards against apt upgrade inside the container drifting quarto off
-    # the pinned version the image is labeled with.
+    # Guards against apt upgrade drifting quarto off the pinned version.
     exec: apt-mark showhold
     exit-status: 0
     stdout:


### PR DESCRIPTION
## Summary

- Condense multi-line comment blocks in goss test templates and rendered files to single lines
- Remove block comments where the test name is already self-documenting
- Flatten multiline `documentationUrl` in bakery.yaml