### PR TITLE
Enforce Posit doc style across all README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Posit Connect Container Images
+# Posit Connect container images
 
 Container images for [Posit Connect](https://docs.posit.co/connect/).
 
 > [!NOTE]
-> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The existing images remain supported.
+> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The [rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products) images remain supported.
 
 ## Prerequisites
 
@@ -22,21 +22,21 @@ Container images for [Posit Connect](https://docs.posit.co/connect/).
 | [connect-content](./connect-content/) | [`docker.io/posit/connect-content`](https://hub.docker.com/r/posit/connect-content) | [`ghcr.io/posit-dev/connect-content`](https://github.com/posit-dev/images-connect/pkgs/container/connect-content) |
 | [connect-content-init](./connect-content-init/) | [`docker.io/posit/connect-content-init`](https://hub.docker.com/r/posit/connect-content-init) | [`ghcr.io/posit-dev/connect-content-init`](https://github.com/posit-dev/images-connect/pkgs/container/connect-content-init) |
 
-Additional Posit container images are published to [Docker Hub](https://hub.docker.com/u/posit) and [GitHub Container Registry](https://github.com/orgs/posit-dev/packages).
+Posit publishes additional container images to [Docker Hub](https://hub.docker.com/u/posit) and [GitHub Container Registry](https://github.com/orgs/posit-dev/packages).
 
-## Running the Images
+## Running the images
 
 For local Docker, you only need the `connect` image. The `connect-content` and `connect-content-init` images are for Kubernetes deployments, where published content runs in separate pods from the Connect server.
 
-- [Posit Connect](./connect/) — The Connect server
-- [Connect Content](./connect-content/) — Runtime images for executing content (Kubernetes)
-- [Connect Content Init](./connect-content-init/) — Init container for Kubernetes deployments
+- [Connect](./connect/): the Connect server
+- [Connect Content](./connect-content/): runtime images for executing content (Kubernetes)
+- [Connect Content Init](./connect-content-init/): init container for Kubernetes deployments
 
 See the [Connect installation guide](https://docs.posit.co/connect/admin/getting-started/) for full setup instructions.
 
 ## Deploying on Kubernetes
 
-Use the [Posit Connect Helm chart](https://docs.posit.co/helm/charts/rstudio-connect/README.html) to deploy on Kubernetes.
+Use the [Connect Helm chart](https://docs.posit.co/helm/charts/rstudio-connect/README.html) to deploy on Kubernetes.
 
 ```bash
 helm repo add rstudio https://helm.rstudio.com
@@ -114,7 +114,7 @@ helm upgrade --install connect rstudio/rstudio-connect --values values.yaml
 
 See the [full chart documentation](https://docs.posit.co/helm/charts/rstudio-connect/README.html) for all available values.
 
-## Building from Source
+## Building from source
 
 You can interact with this repository in multiple ways:
 
@@ -124,12 +124,12 @@ You can interact with this repository in multiple ways:
 
 ## Build
 
-You can build OCI container images from the definitions in this repository using one of the following container build tools:
+You can build Open Container Initiative (OCI) container images from the definitions in this repository using one of the following container build tools:
 
 * [buildah](https://github.com/containers/buildah/blob/main/install.md)
 * [docker buildx](https://github.com/docker/buildx#installing)
 
-The root of the bakery project is used as the build context for each Containerfile.
+Each Containerfile uses the root of the repository as its build context.
 Here, the [`bakery.yaml`](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md#bakery-configuration) file, or project, is in the root of this repository.
 
 ```shell
@@ -156,7 +156,7 @@ podman build \
 
 ## Using `bakery`
 
-The structure and contents of this repository were created following the steps in [bakery usage](https://github.com/posit-dev/images-shared/tree/main/posit-bakery#usage).
+The repository structure follows the steps in [bakery usage](https://github.com/posit-dev/images-shared/tree/main/posit-bakery#usage).
 
 Additional documentation:
 - [Configuration Reference](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md) — `bakery.yaml` schema and options
@@ -211,11 +211,11 @@ bakery run dgoss
 
 You can use CLI flags to limit the tests to run against a subset of images.
 
-## Related Repositories
+## Related repositories
 
 This repository is part of the [Posit Container Images](https://github.com/posit-dev/images) ecosystem. To extend the Minimal image with additional languages or system dependencies, see the [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending). For shared build tooling and CI workflows, see [images-shared](https://github.com/posit-dev/images-shared).
 
-## Share your Feedback
+## Share your feedback
 
 We invite you to join us on [GitHub Discussions](https://github.com/posit-dev/images/discussions) to ask questions and share feedback.
 
@@ -229,4 +229,4 @@ We expect all contributors to adhere to the project's [Code of Conduct](CODE_OF_
 
 ## License
 
-Posit Container Images and associated tooling are licensed under the [MIT License](LICENSE.md)
+Posit licenses these container images and associated tooling under the [MIT License](LICENSE.md).

--- a/connect-content-init/README.md
+++ b/connect-content-init/README.md
@@ -1,13 +1,13 @@
-# Posit Connect Content Init Container Image
+# Posit Connect Content Init container image
 
-This container image is an "init container" used to pull runtime components into another container, which can then be used with Posit Connect and Launcher to build and run content. This image is primarily used in Kubernetes deployments and is leveraged by the Posit Connect Helm chart.
+This container image is an "init container" that pulls runtime components into another container, which Posit Connect and Launcher can then use to build and run content. Kubernetes deployments primarily use this image, and the Connect Helm chart uses it by default.
 
 > [!NOTE]
-> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The existing images remain supported.
+> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The [rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products) images remain supported.
 
 ## Overview
 
-The `connect-content-init` container provides runtime components that are copied into a shared volume during pod initialization. These components enable Posit Connect to execute content in isolated Kubernetes pods via the Launcher.
+The `connect-content-init` container provides runtime components that the init process copies into a shared volume during pod initialization. These components enable Connect to execute content in isolated Kubernetes pods via the Launcher.
 
 | Image | Description | Docker Hub | GHCR |
 |:------|:------------|:-----------|:-----|
@@ -17,24 +17,24 @@ The `connect-content-init` container provides runtime components that are copied
 
 See the [repository README](https://github.com/posit-dev/images-connect#deploying-on-kubernetes) for Helm configuration.
 
-This container [can be extended to include additional content](https://docs.posit.co/helm/examples/connect/container-images/custom-images.html) beyond what is provided by default.
+You can [extend this container to include additional content](https://docs.posit.co/helm/examples/connect/container-images/custom-images.html) beyond the default set.
 
-## Image Tags
+## Image tags
 
-Images are published to:
+Posit publishes images to:
 - Docker Hub: `docker.io/posit/connect-content-init`
 - GitHub Container Registry: `ghcr.io/posit-dev/connect-content-init`
 
-Tag formats:
+The tag formats are:
 - `2026.04.0` - Full version (Ubuntu 24.04)
 - `2026.04.0-ubuntu-24.04` - Explicit OS
 - `latest` - Latest stable release (Ubuntu 24.04)
 
 ## Usage
 
-This image is designed to be used as an init container in Kubernetes. It copies runtime components to a shared volume that is then mounted by the content execution container.
+Use this image as an init container in Kubernetes. It copies runtime components to a shared volume that the content execution container then mounts.
 
-### Kubernetes Init Container Example
+### Kubernetes init container example
 
 ```yaml
 initContainers:
@@ -45,9 +45,9 @@ initContainers:
         mountPath: /opt/rstudio-connect-runtime
 ```
 
-### Helm Chart
+### Helm chart
 
-This image is used automatically when deploying Posit Connect via the official Helm chart. For more information, see the [Posit Connect Helm Chart documentation](https://docs.posit.co/helm/charts/rstudio-connect/README.html).
+The official Helm chart uses this image automatically when deploying Connect. For more information, see the [Connect Helm chart documentation](https://docs.posit.co/helm/charts/rstudio-connect/README.html).
 
 ## Differences from rstudio/rstudio-connect-content-init
 
@@ -62,9 +62,9 @@ This image differs from the legacy [`rstudio/rstudio-connect-content-init`](http
 
 ### Security
 
-These images should be reviewed before production use. Organizations with specific CVE or vulnerability requirements should rebuild these images to meet their security standards.
+Review these images before production use. Organizations with specific Common Vulnerabilities and Exposures (CVE) or vulnerability requirements must rebuild these images to meet their security standards.
 
-Published images for Posit Product editions under active support are re-built on a weekly basis to pull in operating system patches.
+Posit rebuilds published images for Posit product editions under active support weekly to pull in operating system patches.
 
 ## Documentation
 

--- a/connect-content/README.md
+++ b/connect-content/README.md
@@ -1,13 +1,13 @@
-# Posit Connect Content Container Images
+# Posit Connect Content container image
 
 These container images provide the runtime environments for executing content deployed to [Posit Connect](https://docs.posit.co/connect/) in Kubernetes. Each image includes a specific combination of R, Python, and Quarto.
 
 > [!NOTE]
-> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The existing images remain supported.
+> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The [rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products) images remain supported.
 
 ## Overview
 
-When [Posit Connect](https://docs.posit.co/connect/) runs on Kubernetes with the Job Launcher, published content (Shiny apps, Plumber APIs, Quarto documents, Jupyter notebooks, etc.) executes inside content containers. Each `connect-content` image provides a specific R and Python version pair.
+When [Connect](https://docs.posit.co/connect/) runs on Kubernetes with the Job Launcher, published content (Shiny apps, Plumber APIs, Quarto documents, Jupyter notebooks, etc.) executes inside content containers. Each `connect-content` image provides a specific R and Python version pair.
 
 | Image | Description | Docker Hub | GHCR |
 |:------|:------------|:-----------|:-----|
@@ -17,26 +17,26 @@ When [Posit Connect](https://docs.posit.co/connect/) runs on Kubernetes with the
 
 See the [repository README](https://github.com/posit-dev/images-connect#deploying-on-kubernetes) for Helm configuration.
 
-## Image Variants
+## Image variants
 
 | Variant | Tag Suffix | Description |
 |---------|------------|-------------|
 | Base | (none) | Open-source R and Python |
 | Pro | `-pro` | Includes Posit Professional Drivers for database connectivity |
 
-## Image Tags
+## Image tags
 
-Images are published to:
+Posit publishes images to:
 - Docker Hub: `docker.io/posit/connect-content`
 - GitHub Container Registry: `ghcr.io/posit-dev/connect-content`
 
-Tag format: `R{r_version}-python{python_version}-{os}[-pro]`
+The tag format is: `R{r_version}-python{python_version}-{os}[-pro]`
 
 Examples:
 - `R4.5.2-python3.14.3-ubuntu-24.04` — R 4.5.2, Python 3.14.3, Ubuntu 24.04
 - `R4.4.3-python3.12.12-ubuntu-24.04-pro` — Same versions with pro drivers
 
-## Available Versions
+## Available versions
 
 The standard set of content images covers a matrix of R and Python versions:
 
@@ -48,13 +48,13 @@ The standard set of content images covers a matrix of R and Python versions:
 
 ## Usage
 
-These images are not run directly. They are configured as execution environments in Posit Connect, either through:
+Do not run these images directly. Configure them as execution environments in Connect, either through:
 
-1. **Helm chart values** — The `rstudio/rstudio-connect` Helm chart includes a default set of content images. See the [repository README](../README.md#deploying-on-kubernetes) for configuration details.
-2. **Connect admin dashboard** — Execution environments can be managed in the Connect UI under Admin > Execution Environments.
-3. **runtime.yaml** — A YAML configuration file defining available execution environments.
+1. **Helm chart values:** The `rstudio/rstudio-connect` Helm chart includes a default set of content images. See the [repository README](../README.md#deploying-on-kubernetes) for configuration details.
+2. **Connect admin dashboard:** Manage execution environments in the Connect UI under **Admin > Execution environments**.
+3. **runtime.yaml:** A YAML configuration file that defines available execution environments.
 
-## Installed Software
+## Installed software
 
 Each image includes:
 

--- a/connect/README.md
+++ b/connect/README.md
@@ -1,11 +1,11 @@
-# Posit Connect Container Image
+# Posit Connect container image
 
 This container image provides [Posit Connect](https://docs.posit.co/connect/) (PCT), a publishing platform that connects you and the work you do with others. Deploy Shiny applications, R Markdown documents, Plumber APIs, Python applications (Flask, Dash, FastAPI, Bokeh, Streamlit), Jupyter notebooks, Quarto documents, and more.
 
 > [!NOTE]
-> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The existing images remain supported.
+> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The [rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products) images remain supported.
 
-## Related Images
+## Related images
 
 For Kubernetes deployments, Connect uses all three images together. See the [repository README](https://github.com/posit-dev/images-connect#deploying-on-kubernetes) for Helm configuration.
 
@@ -14,7 +14,7 @@ For Kubernetes deployments, Connect uses all three images together. See the [rep
 | `connect-content` | Runtime images for executing published content | [posit/connect-content](https://hub.docker.com/r/posit/connect-content) | [posit-dev/connect-content](https://github.com/posit-dev/images-connect/pkgs/container/connect-content) |
 | `connect-content-init` | Init container for Kubernetes deployments | [posit/connect-content-init](https://hub.docker.com/r/posit/connect-content-init) | [posit-dev/connect-content-init](https://github.com/posit-dev/images-connect/pkgs/container/connect-content-init) |
 
-## Quick Start
+## Quick start
 
 ```bash
 PCT_VERSION="2026.04.0"
@@ -28,37 +28,37 @@ docker run -d \
   ${PCT_IMAGE}:${PCT_VERSION}
 ```
 
-Access Posit Connect at `http://localhost:3939`.
+Access Connect at `http://localhost:3939`.
 
 > [!NOTE]
-> The `--privileged` flag is required for Connect to manage sandboxed content execution environments.
-> This example does not mount a data volume. Application data will not persist when the container stops. See [Volume Mounts](#volume-mounts) for persistent storage.
+> Connect requires the `--privileged` flag to manage sandboxed content execution environments.
+> This example does not mount a data volume. Application data will not persist when the container stops. See [Volume mounts](#volume-mounts) for persistent storage.
 
 > [!IMPORTANT]
-> To use Posit Connect with more than one user, define `Server.Address` in
+> To use Connect with more than one user, define `Server.Address` in
 > the `rstudio-connect.gcfg` file. Set it to the URL that users will use to
 > visit Connect, then start or restart the container.
 
-## Image Variants
+## Image variants
 
 Two variants are available:
 
 | Variant | Description |
 |---------|-------------|
 | `std` (Standard) | Opinionated image with R, Python, and Quarto pre-installed, runs out of the box |
-| `min` (Minimal) | Small image you can extend with desired dependencies, *will not run as is* |
+| `min` (Minimal) | Small image you can extend with desired dependencies; will not run as is |
 
 See [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending) for how to build on the Minimal image.
 
-## Image Tags
+## Image tags
 
-Images are published to:
+Posit publishes images to:
 - Docker Hub: `docker.io/posit/connect`
 - GitHub Container Registry: `ghcr.io/posit-dev/connect`
 
 Ubuntu 24.04 is the default OS.
 
-Tag formats:
+The tag formats are:
 - `2026.04.0` - Latest OS, standard variant
 - `2026.04.0-ubuntu-24.04` - Explicit OS, standard variant
 - `2026.04.0-ubuntu-24.04-std` - Explicit OS and variant
@@ -67,26 +67,29 @@ Tag formats:
 
 ## Configuration
 
-### License Activation
+### License activation
 
-A [product license](https://docs.posit.co/licensing/licensing-faq.html) is required. Posit recommends license file activation. Connect must also run with the `--privileged` flag. Choose one activation method:
+Connect requires a [product license](https://docs.posit.co/licensing/licensing-faq.html). Posit recommends license file activation. Connect must also run with the `--privileged` flag. Choose one activation method:
 
-**Option 1: License File (Recommended)**
+#### Option 1: License file (recommended)
+
 ```bash
 docker run --privileged -v /path/to/license.lic:/etc/rstudio-connect/license.lic ...
 ```
 
-**Option 2: License Key**
+#### Option 2: License key
+
 ```bash
 docker run --privileged -e PCT_LICENSE="your-license-key" ...
 ```
 
-**Option 3: Floating License Server**
+#### Option 3: Floating license server
+
 ```bash
 docker run --privileged -e PCT_LICENSE_SERVER="license-server:port" ...
 ```
 
-### Environment Variables
+### Environment variables
 
 | Variable              | Description                                                   |
 |-----------------------|---------------------------------------------------------------|
@@ -95,7 +98,7 @@ docker run --privileged -e PCT_LICENSE_SERVER="license-server:port" ...
 | `PCT_LICENSE_FILE_PATH` | Path to license file (default: `/etc/rstudio-connect/license.lic`) |
 | `STARTUP_DEBUG_MODE`  | Set to `1` for verbose startup logging                        |
 
-#### Legacy Environment Variables
+#### Legacy environment variables
 
 | Legacy Variable        | Preferred Equivalent   | Notes         |
 |------------------------|------------------------|---------------|
@@ -103,9 +106,10 @@ docker run --privileged -e PCT_LICENSE_SERVER="license-server:port" ...
 | `RSC_LICENSE_SERVER`   | `PCT_LICENSE_SERVER`   | Same behavior |
 | `RSC_LICENSE_FILE_PATH`| `PCT_LICENSE_FILE_PATH`| Same behavior |
 
-**Note:** Legacy `RSC_` variables are supported for backward compatibility but are planned for deprecation. For more details and updates, see the [Posit Connect release notes](https://docs.posit.co/connect/news/). For new deployments, always use the `PCT_` prefix to ensure forward compatibility.
+> [!NOTE]
+> Connect supports legacy `RSC_` variables for backward compatibility but plans to deprecate them. For more details and updates, see the [Connect release notes](https://docs.posit.co/connect/news/). For new deployments, always use the `PCT_` prefix to ensure forward compatibility.
 
-### Volume Mounts
+### Volume mounts
 
 For persistent data, add these volume mounts to your `docker run` command:
 
@@ -119,7 +123,7 @@ For persistent data, add these volume mounts to your `docker run` command:
 | `/data`                 | Application data and database |
 | `/etc/rstudio-connect`  | Configuration files |
 
-### Custom Configuration
+### Custom configuration
 
 Mount a custom configuration file:
 
@@ -136,7 +140,7 @@ Be sure the config file has these fields:
 
 See the [configuration documentation](https://docs.posit.co/connect/admin/appendix/configuration/) for available options.
 
-## Exposed Ports
+## Exposed ports
 
 | Port | Description |
 |------|-------------|
@@ -144,7 +148,7 @@ See the [configuration documentation](https://docs.posit.co/connect/admin/append
 
 ## User
 
-Runs as the `rstudio-connect` user (UID/GID 999).
+Runs as the `rstudio-connect` user (UID and GID 999).
 
 ## Differences from rstudio/rstudio-connect
 
@@ -161,17 +165,17 @@ This image differs from the legacy [`rstudio/rstudio-connect`](https://hub.docke
 
 ### Security
 
-These images should be reviewed before production use. Organizations with specific CVE or vulnerability requirements should rebuild these images to meet their security standards.
+Review these images before production use. Organizations with specific Common Vulnerabilities and Exposures (CVE) or vulnerability requirements must rebuild these images to meet their security standards.
 
-Published images for Posit Product editions under active support are re-built on a weekly basis to pull in operating system patches.
+Posit rebuilds published images for Posit product editions under active support weekly to pull in operating system patches.
 
-### Privileged Mode
+### Privileged mode
 
-Posit Connect requires the `--privileged` flag to run containers. This is necessary for Connect to execute user content in isolated environments.
+Connect requires the `--privileged` flag to run containers. This is necessary for Connect to execute user content in isolated environments.
 
-### License Keys
+### License keys
 
-License keys used in containers risk activation slot loss if containers aren't gracefully stopped. The license deactivates on container exit, but ungraceful shutdowns (crashes, `docker kill`) may leave the activation slot consumed on Posit's license server.
+License keys used in containers risk activation slot loss if containers are not gracefully stopped. The license deactivates on container exit, but ungraceful shutdowns (crashes, `docker kill`) might leave the activation slot consumed on the Posit license server.
 
 To avoid "leaking" licenses, use a sufficient stop timeout:
 
@@ -183,7 +187,7 @@ docker run -d \
   ...
 ```
 
-For production deployments, license files are recommended over license keys.
+For production deployments, Posit recommends license files over license keys.
 
 To preserve license state data across container restarts, mount these directories to persistent storage:
 
@@ -194,9 +198,9 @@ To preserve license state data across container restarts, mount these directorie
 * Floating License
   * `/var/lib/.TurboFloat`
 
-### Hardware Locking
+### Hardware locking
 
-License state files are hardware-locked. Changes to MAC addresses, hostnames, or container orchestration platforms, such as Kubernetes, may invalidate existing license state, requiring reactivation.
+Connect hardware-locks license state files. Changes to MAC addresses, hostnames, or container orchestration platforms, such as Kubernetes, might invalidate the license state, requiring reactivation.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Ran `/doc-reviewer:doc-reviewer` against every `README.md` in the repository to enforce the Posit documentation style guide (sentence-case headings, active voice, short-form `Connect` after first mention, no em dashes, no contractions, spelled-out acronyms on first use, etc.).
- Applied the resulting fixes across the root README and the three image READMEs (`connect`, `connect-content`, `connect-content-init`), one commit per file for easy review.
- Linked the legacy `rstudio-docker-products` reference in each preview-status NOTE callout, promoted bold pseudo-headings in `connect/README.md` to real subheadings, and replaced LLM-style bold-concept-em-dash list items in `connect-content/README.md` with colon run-ins.

The intent is for `/doc-reviewer:doc-reviewer` to be the standing mechanism for keeping these files aligned with Posit documentation standards going forward.

## Test plan

- [ ] Render each README on GitHub and confirm formatting (callouts, tables, code blocks) still displays correctly
- [ ] Spot-check the registry-published READMEs (`connect`, `connect-content`, `connect-content-init`) on Docker Hub once a build pushes
- [ ] Re-run `/doc-reviewer:doc-reviewer` to confirm no remaining high/medium violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)