### PR TITLE
Fix latest version badge for Content images

### DIFF
--- a/connect-content-init/README.md
+++ b/connect-content-init/README.md
@@ -36,7 +36,7 @@ This container image is an init container for Connect that pulls runtime compone
 
 For Kubernetes deployments, Connect uses three images together. See the [repository README](https://github.com/posit-dev/images-connect#deploying-on-kubernetes) for Helm configuration.
 
-| Image | Description | Docker Hub | GHCR |
+| Image | Description | Docker Hub | GitHub Container Registry |
 |:------|:------------|:-----------|:-----|
 | `connect` | The Connect server | [posit/connect](https://hub.docker.com/r/posit/connect) | [posit-dev/connect](https://github.com/posit-dev/images-connect/pkgs/container/connect) |
 | `connect-content` | Runtime images for executing published content | [posit/connect-content](https://hub.docker.com/r/posit/connect-content) | [posit-dev/connect-content](https://github.com/posit-dev/images-connect/pkgs/container/connect-content) |

--- a/connect-content/README.md
+++ b/connect-content/README.md
@@ -37,7 +37,7 @@ These container images provide the runtime environments for executing content de
 
 For Kubernetes deployments, Connect uses three images together. See the [repository README](https://github.com/posit-dev/images-connect#deploying-on-kubernetes) for Helm configuration.
 
-| Image | Description | Docker Hub | GHCR |
+| Image | Description | Docker Hub | GitHub Container Registry |
 |:------|:------------|:-----------|:-----|
 | `connect` | The Posit Connect server | [posit/connect](https://hub.docker.com/r/posit/connect) | [posit-dev/connect](https://github.com/posit-dev/images-connect/pkgs/container/connect) |
 | `connect-content-init` | Init container for Kubernetes deployments | [posit/connect-content-init](https://hub.docker.com/r/posit/connect-content-init) | [posit-dev/connect-content-init](https://github.com/posit-dev/images-connect/pkgs/container/connect-content-init) |

--- a/connect-content/README.md
+++ b/connect-content/README.md
@@ -12,12 +12,9 @@ These container images provide the runtime environments for executing content de
 
 [![GitHub Repository](https://img.shields.io/badge/github-repo?logo=github&color=grey)](https://github.com/posit-dev/images-connect)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/posit-dev/images-connect/content.yml?branch=main)](https://github.com/posit-dev/images-connect/actions/workflows/content.yml)
+[![Latest Version](https://img.shields.io/docker/v/posit/connect-content/latest?sort=semver&label=latest)](https://hub.docker.com/r/posit/connect-content/tags)
 ![Docker Pulls](https://img.shields.io/docker/pulls/posit/connect-content)
 ![Docker Image Size](https://img.shields.io/docker/image-size/posit/connect-content/latest)
-<!--
-TODO: Try this again after the [deterministic push order PR is merged](https://github.com/posit-dev/images-shared/pull/505)
-[![Latest Version](https://img.shields.io/docker/v/posit/connect-content?sort=date&label=latest)](https://hub.docker.com/r/posit/connect-content/tags)
--->
 
 > [!NOTE]
 > These images are in preview as Posit migrates container images from <a href="https://github.com/rstudio/rstudio-docker-products">rstudio/rstudio-docker-products</a>. The previous `rstudio/content-base` and `rstudio/content-pro` images remain supported.

--- a/connect/README.md
+++ b/connect/README.md
@@ -37,7 +37,7 @@ This container image provides [Connect](https://docs.posit.co/connect/), a publi
 
 For Kubernetes deployments, Connect uses three images together. See the [repository README](https://github.com/posit-dev/images-connect#deploying-on-kubernetes) for Helm configuration.
 
-| Image | Description | Docker Hub | GHCR |
+| Image | Description | Docker Hub | GitHub Container Registry |
 |:------|:------------|:-----------|:-----|
 | `connect-content` | Runtime images for executing published content | [posit/connect-content](https://hub.docker.com/r/posit/connect-content) | [posit-dev/connect-content](https://github.com/posit-dev/images-connect/pkgs/container/connect-content) |
 | `connect-content-init` | Init container for Kubernetes deployments | [posit/connect-content-init](https://hub.docker.com/r/posit/connect-content-init) | [posit-dev/connect-content-init](https://github.com/posit-dev/images-connect/pkgs/container/connect-content-init) |


### PR DESCRIPTION
I didn't realize #81 was merged already.

- Fix latest version badge for Content
- Expand GHCR to GitHub Container Registry in Related images tables