### PR TITLE
Restagger crons: 02:15 prod, 02:45 content, 08:45 daily

### DIFF
--- a/.github/workflows/content.yml
+++ b/.github/workflows/content.yml
@@ -4,7 +4,9 @@ on:
 
   schedule:
     # Weekly rebuild of all images, to pick up any upstream changes.
-    - cron: "15 4 * * 0" # At 04:15 on Sunday
+    # Runs in the same hour as Connect production (02:15 Sun) but at
+    # minute 45 so the content matrix follows the main Connect rebuild.
+    - cron: "45 2 * * 0" # At 02:45 on Sunday
 
   push:
     branches:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,8 +1,11 @@
 name: Development
 on:
   schedule:
-    # Daily rebuild of dev images
-    - cron: "45 4 * * *" # At 04:45 every day
+    # Daily rebuild of dev images. Staggered with images-package-manager
+    # (07:45) and images-workbench (09:45) so the three products don't
+    # all build in the same hour. Weeklies run at 01–03 UTC, dailies at
+    # 07–09 UTC, with 04–06 UTC reserved as growth headroom.
+    - cron: "45 8 * * *" # At 08:45 every day
 
   push:
     branches:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,7 +4,11 @@ on:
 
   schedule:
     # Weekly rebuild of all images, to pick up any upstream changes.
-    - cron: "15 3 * * 0" # At 03:15 on Sunday
+    # Staggered with images-package-manager production (01:15 Sun) and
+    # images-workbench production (03:15 Sun) so the three products
+    # don't all build in the same hour. Connect content shares this hour
+    # at minute 45.
+    - cron: "15 2 * * 0" # At 02:15 on Sunday
 
   push:
     branches:


### PR DESCRIPTION
Restagger this repo's crons into the wider weekly + daily schedule agreed across images-* (PPM/Connect/Workbench).

- `development.yml`: `45 5 * * *` → `45 8 * * *` (daily 05:45 → 08:45)
- `production.yml`: `15 3 * * 0` → `15 2 * * 0` (weekly 03:15 → 02:15)
- `content.yml`: `15 4 * * 0` → `45 2 * * 0` (matrix 04:15 → 02:45, same hour as Connect prod but later in the hour so content follows the main rebuild)

Window layout:
- Weeklies at 01–03 UTC Sun
- 04–06 UTC reserved as growth headroom
- Dailies at 07–09 UTC

Part of posit-dev/images-shared#326.