### PR TITLE
Bump actions/create-github-app-token to v3.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
       - "/"
       - "/.github/actions/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: GitHub App Token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}


### PR DESCRIPTION
- Bump `actions/create-github-app-token` from v3.1.1 (`1b10c78c7865c340bc4f6099eb2f838309f1e8c3`) to v3.2.0 (`bcd2ba49218906704ab6c1aa796996da409d3eb1`).
- Slow the dependabot actions group from weekly to monthly so this PR stays quiet.