### PR TITLE
Restore xz-utils apt block in connect 2026.03 std

### DIFF
--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -92,6 +92,11 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
+    apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -92,6 +92,11 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
+    apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.03/test/goss.yaml
+++ b/connect/2026.03/test/goss.yaml
@@ -134,10 +134,12 @@ command:
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: "HOME='/opt' quarto list tools"
+    exec: quarto list tools
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
+      - "/tinytex\\s+External Installation/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify ODBC drivers are configured":
     exec: cat /etc/odbcinst.ini


### PR DESCRIPTION
Reverts the connect/2026.03 portion of https://github.com/posit-dev/images-connect/pull/98. After that PR merged, production CI for `connect:2026.03 (linux/amd64)` started failing the goss test `Ensure Quarto symlink works` (`/usr/local/bin/quarto check --quiet` exiting 1) on the ubuntu-22.04 standard variant. The ubuntu-24.04 standard variant and all 2026.04 variants pass with the same change.

The 2026.03 image pins quarto=1.9.36 and the 2026.04 image pins quarto=1.9.37, so the difference appears to be a quirk of `quarto check` on 1.9.36 + ubuntu-22.04 once TinyTeX is detected as a managed install (`Up to date`) instead of `External Installation`. Restoring the inline apt block flips TinyTeX detection back to `External Installation` on this version and `quarto check` exits 0 again.

The template, connect-content matrix, and 2026.04 rendered files keep the cleaner pattern from #98. Only 2026.03 reverts.

Failing run before this fix: https://github.com/posit-dev/images-connect/actions/runs/26117658953