### PR TITLE
Configure apt retries in rendered Containerfiles

### DIFF
--- a/connect-content-init/2025.05/Containerfile.ubuntu2204
+++ b/connect-content-init/2025.05/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2025.05.0"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2025.06/Containerfile.ubuntu2204
+++ b/connect-content-init/2025.06/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2025.06.0"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2025.07/Containerfile.ubuntu2204
+++ b/connect-content-init/2025.07/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2025.07.0"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2025.09/Containerfile.ubuntu2204
+++ b/connect-content-init/2025.09/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2025.09.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2025.10/Containerfile.ubuntu2204
+++ b/connect-content-init/2025.10/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2025.10.0"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2025.11/Containerfile.ubuntu2204
+++ b/connect-content-init/2025.11/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2025.11.0"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2025.12/Containerfile.ubuntu2204
+++ b/connect-content-init/2025.12/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2025.12.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2025.12/Containerfile.ubuntu2404
+++ b/connect-content-init/2025.12/Containerfile.ubuntu2404
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2025.12.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2026.01/Containerfile.ubuntu2204
+++ b/connect-content-init/2026.01/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2026.01.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2026.01/Containerfile.ubuntu2404
+++ b/connect-content-init/2026.01/Containerfile.ubuntu2404
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2026.01.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2026.02/Containerfile.ubuntu2204
+++ b/connect-content-init/2026.02/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2026.02.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2026.02/Containerfile.ubuntu2404
+++ b/connect-content-init/2026.02/Containerfile.ubuntu2404
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2026.02.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2026.03/Containerfile.ubuntu2204
+++ b/connect-content-init/2026.03/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2026.03.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2026.03/Containerfile.ubuntu2404
+++ b/connect-content-init/2026.03/Containerfile.ubuntu2404
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2026.03.1"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2026.04/Containerfile.ubuntu2204
+++ b/connect-content-init/2026.04/Containerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2026.04.0"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content-init/2026.04/Containerfile.ubuntu2404
+++ b/connect-content-init/2026.04/Containerfile.ubuntu2404
@@ -12,7 +12,8 @@ ARG CONNECT_VERSION="2026.04.0"
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -36,7 +36,8 @@ ENV LC_ALL=en_US.UTF-8
 ENV TZ=UTC
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -36,7 +36,8 @@ ENV LC_ALL=en_US.UTF-8
 ENV TZ=UTC
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -36,7 +36,8 @@ ENV LC_ALL=en_US.UTF-8
 ENV TZ=UTC
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -36,7 +36,8 @@ ENV LC_ALL=en_US.UTF-8
 ENV TZ=UTC
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.05/Containerfile.ubuntu2204.min
+++ b/connect/2025.05/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.06/Containerfile.ubuntu2204.min
+++ b/connect/2025.06/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.07/Containerfile.ubuntu2204.min
+++ b/connect/2025.07/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.09/Containerfile.ubuntu2204.min
+++ b/connect/2025.09/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.10/Containerfile.ubuntu2204.min
+++ b/connect/2025.10/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.11/Containerfile.ubuntu2204.min
+++ b/connect/2025.11/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.12/Containerfile.ubuntu2204.min
+++ b/connect/2025.12/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.12/Containerfile.ubuntu2404.min
+++ b/connect/2025.12/Containerfile.ubuntu2404.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.01/Containerfile.ubuntu2204.min
+++ b/connect/2026.01/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.01/Containerfile.ubuntu2404.min
+++ b/connect/2026.01/Containerfile.ubuntu2404.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.02/Containerfile.ubuntu2204.min
+++ b/connect/2026.02/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.02/Containerfile.ubuntu2404.min
+++ b/connect/2026.02/Containerfile.ubuntu2404.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.03/Containerfile.ubuntu2204.min
+++ b/connect/2026.03/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.03/Containerfile.ubuntu2404.min
+++ b/connect/2026.03/Containerfile.ubuntu2404.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.04/Containerfile.ubuntu2204.min
+++ b/connect/2026.04/Containerfile.ubuntu2204.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.04/Containerfile.ubuntu2204.std
+++ b/connect/2026.04/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.04/Containerfile.ubuntu2404.min
+++ b/connect/2026.04/Containerfile.ubuntu2404.min
@@ -21,7 +21,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/connect/2026.04/Containerfile.ubuntu2404.std
+++ b/connect/2026.04/Containerfile.ubuntu2404.std
@@ -31,7 +31,8 @@ ENV PCT_STARTUP_DEBUG=0
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Run setup ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \


### PR DESCRIPTION
## Why

Adds `Acquire::Retries=3` and `Acquire::http(s)::Timeout=30` to `/etc/apt/apt.conf.d/99-retries` at the top of each first apt RUN. Transient timeouts on `archive.ubuntu.com` and `ports.ubuntu.com` now recover on retry instead of failing the build.

Surgical edit to the rendered Containerfiles to avoid touching unrelated files. The macro change producing this output going forward landed upstream:

- https://github.com/posit-dev/images-shared/pull/538