### PR TITLE
Remove --quiet from quarto tinytex install commands

### DIFF
--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -84,5 +84,5 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -95,5 +95,5 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -84,5 +84,5 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -95,5 +95,5 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -98,7 +98,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.04/Containerfile.ubuntu2204.std
+++ b/connect/2026.04/Containerfile.ubuntu2204.std
@@ -93,7 +93,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.04/Containerfile.ubuntu2404.std
+++ b/connect/2026.04/Containerfile.ubuntu2404.std
@@ -93,7 +93,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###


### PR DESCRIPTION
The `--quiet` flag suppresses `quarto install tinytex` output,
including the actual error message when the install fails. Recent
CI flakes related to GitHub API rate limits during the install were
nearly impossible to diagnose because of this.

Directly edit the rendered Containerfiles to drop `--quiet`. The
upstream template fix lives in:

- https://github.com/posit-dev/images-shared/pull/546