### PR TITLE
Add optional packages list for Connect Standard

### DIFF
--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2025.05/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2025.05/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2025.05/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2025.05/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2025.05/test/goss.yaml
+++ b/connect/2025.05/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2025.06/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2025.06/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2025.06/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2025.06/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2025.06/test/goss.yaml
+++ b/connect/2025.06/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2025.07/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2025.07/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2025.07/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2025.07/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2025.07/test/goss.yaml
+++ b/connect/2025.07/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2025.09/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2025.09/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2025.09/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2025.09/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2025.09/test/goss.yaml
+++ b/connect/2025.09/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2025.10/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2025.10/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2025.10/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2025.10/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2025.10/test/goss.yaml
+++ b/connect/2025.10/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2025.11/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2025.11/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2025.11/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2025.11/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2025.11/test/goss.yaml
+++ b/connect/2025.11/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2025.12/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2025.12/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2025.12/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_packages.txt
+COPY connect/2025.12/deps/ubuntu-24.04_optional_packages.txt /tmp/ubuntu-24.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-24.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-24.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2025.12/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2025.12/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2025.12/deps/ubuntu-24.04_optional_packages.txt
+++ b/connect/2025.12/deps/ubuntu-24.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2025.12/test/goss.yaml
+++ b/connect/2025.12/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.01/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2026.01/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.01/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_packages.txt
+COPY connect/2026.01/deps/ubuntu-24.04_optional_packages.txt /tmp/ubuntu-24.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-24.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-24.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2026.01/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2026.01/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2026.01/deps/ubuntu-24.04_optional_packages.txt
+++ b/connect/2026.01/deps/ubuntu-24.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2026.01/test/goss.yaml
+++ b/connect/2026.01/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.02/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2026.02/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.02/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_packages.txt
+COPY connect/2026.02/deps/ubuntu-24.04_optional_packages.txt /tmp/ubuntu-24.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-24.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-24.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2026.02/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2026.02/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2026.02/deps/ubuntu-24.04_optional_packages.txt
+++ b/connect/2026.02/deps/ubuntu-24.04_optional_packages.txt
@@ -1,0 +1,1 @@
+libuv1-dev

--- a/connect/2026.02/test/goss.yaml
+++ b/connect/2026.02/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.03/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2026.03/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 
@@ -93,11 +95,6 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        xz-utils && \
-    apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.03/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_packages.txt
+COPY connect/2026.03/deps/ubuntu-24.04_optional_packages.txt /tmp/ubuntu-24.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-24.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-24.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 
@@ -93,11 +95,6 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        xz-utils && \
-    apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/connect/2026.03/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2026.03/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,2 @@
+libuv1-dev
+xz-utils

--- a/connect/2026.03/deps/ubuntu-22.04_packages.txt
+++ b/connect/2026.03/deps/ubuntu-22.04_packages.txt
@@ -11,4 +11,3 @@ libglib2.0-0
 mime-support
 rrdtool
 tzdata
-xz-utils

--- a/connect/2026.03/deps/ubuntu-24.04_optional_packages.txt
+++ b/connect/2026.03/deps/ubuntu-24.04_optional_packages.txt
@@ -1,0 +1,2 @@
+libuv1-dev
+xz-utils

--- a/connect/2026.03/deps/ubuntu-24.04_packages.txt
+++ b/connect/2026.03/deps/ubuntu-24.04_packages.txt
@@ -5,4 +5,3 @@ libssl3t64
 media-types
 rrdtool
 tzdata
-xz-utils

--- a/connect/2026.03/test/goss.yaml
+++ b/connect/2026.03/test/goss.yaml
@@ -134,12 +134,10 @@ command:
     exit-status: 0
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
-    exec: quarto list tools
+    exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
-      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
-      - "/tinytex\\s+External Installation/"
+      - "/tinytex\\s+Up to date/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify ODBC drivers are configured":
     exec: cat /etc/odbcinst.ini

--- a/connect/2026.03/test/goss.yaml
+++ b/connect/2026.03/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2026.04/Containerfile.ubuntu2204.std
+++ b/connect/2026.04/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.04/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2026.04/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2026.04/Containerfile.ubuntu2404.std
+++ b/connect/2026.04/Containerfile.ubuntu2404.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.04/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_packages.txt
+COPY connect/2026.04/deps/ubuntu-24.04_optional_packages.txt /tmp/ubuntu-24.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-24.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-24.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2026.04/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2026.04/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,2 @@
+libuv1-dev
+xz-utils

--- a/connect/2026.04/deps/ubuntu-22.04_packages.txt
+++ b/connect/2026.04/deps/ubuntu-22.04_packages.txt
@@ -11,4 +11,3 @@ libglib2.0-0
 mime-support
 rrdtool
 tzdata
-xz-utils

--- a/connect/2026.04/deps/ubuntu-24.04_optional_packages.txt
+++ b/connect/2026.04/deps/ubuntu-24.04_optional_packages.txt
@@ -1,0 +1,2 @@
+libuv1-dev
+xz-utils

--- a/connect/2026.04/deps/ubuntu-24.04_packages.txt
+++ b/connect/2026.04/deps/ubuntu-24.04_packages.txt
@@ -5,4 +5,3 @@ libssl3t64
 media-types
 rrdtool
 tzdata
-xz-utils

--- a/connect/2026.04/test/goss.yaml
+++ b/connect/2026.04/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/2026.05/Containerfile.ubuntu2204.std
+++ b/connect/2026.05/Containerfile.ubuntu2204.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.05/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY connect/2026.05/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-22.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-22.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2026.05/Containerfile.ubuntu2404.std
+++ b/connect/2026.05/Containerfile.ubuntu2404.std
@@ -47,8 +47,10 @@ RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Tim
 
 ### Update apt packages ###
 COPY connect/2026.05/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_packages.txt
+COPY connect/2026.05/deps/ubuntu-24.04_optional_packages.txt /tmp/ubuntu-24.04_optional_packages.txt
 RUN apt-get update -yqq && \
     xargs -a /tmp/ubuntu-24.04_packages.txt apt-get install -yqq --no-install-recommends && \
+    xargs -a /tmp/ubuntu-24.04_optional_packages.txt apt-get install -yqq --no-install-recommends && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 

--- a/connect/2026.05/deps/ubuntu-22.04_optional_packages.txt
+++ b/connect/2026.05/deps/ubuntu-22.04_optional_packages.txt
@@ -1,0 +1,2 @@
+libuv1-dev
+xz-utils

--- a/connect/2026.05/deps/ubuntu-22.04_packages.txt
+++ b/connect/2026.05/deps/ubuntu-22.04_packages.txt
@@ -11,4 +11,3 @@ libglib2.0-0
 mime-support
 rrdtool
 tzdata
-xz-utils

--- a/connect/2026.05/deps/ubuntu-24.04_optional_packages.txt
+++ b/connect/2026.05/deps/ubuntu-24.04_optional_packages.txt
@@ -1,0 +1,2 @@
+libuv1-dev
+xz-utils

--- a/connect/2026.05/deps/ubuntu-24.04_packages.txt
+++ b/connect/2026.05/deps/ubuntu-24.04_packages.txt
@@ -5,4 +5,3 @@ libssl3t64
 media-types
 rrdtool
 tzdata
-xz-utils

--- a/connect/2026.05/test/goss.yaml
+++ b/connect/2026.05/test/goss.yaml
@@ -18,6 +18,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
 

--- a/connect/template/Containerfile.ubuntu2204.jinja2
+++ b/connect/template/Containerfile.ubuntu2204.jinja2
@@ -39,8 +39,14 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 {{ apt.run_setup() }}
 
 ### Update apt packages ###
+{% if Image.Variant != "Minimal" -%}
+COPY {{ Path.Version }}/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
+COPY {{ Path.Version }}/deps/ubuntu-22.04_optional_packages.txt /tmp/ubuntu-22.04_optional_packages.txt
+{{ apt.run_install(files=["/tmp/ubuntu-22.04_packages.txt", "/tmp/ubuntu-22.04_optional_packages.txt"]) }}
+{% else -%}
 COPY {{ Path.Version }}/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
 {{ apt.run_install(files="/tmp/ubuntu-22.04_packages.txt") }}
+{%- endif %}
 
 {% if Image.Variant != "Minimal" -%}
 ### Install Pro Drivers ###

--- a/connect/template/Containerfile.ubuntu2404.jinja2
+++ b/connect/template/Containerfile.ubuntu2404.jinja2
@@ -39,8 +39,14 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 {{ apt.run_setup() }}
 
 ### Update apt packages ###
+{% if Image.Variant != "Minimal" -%}
+COPY {{ Path.Version }}/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_packages.txt
+COPY {{ Path.Version }}/deps/ubuntu-24.04_optional_packages.txt /tmp/ubuntu-24.04_optional_packages.txt
+{{ apt.run_install(files=["/tmp/ubuntu-24.04_packages.txt", "/tmp/ubuntu-24.04_optional_packages.txt"]) }}
+{% else -%}
 COPY {{ Path.Version }}/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_packages.txt
 {{ apt.run_install(files="/tmp/ubuntu-24.04_packages.txt") }}
+{%- endif %}
 
 {% if Image.Variant != "Minimal" -%}
 ### Install Pro Drivers ###

--- a/connect/template/deps/ubuntu-22.04_optional_packages.txt.jinja2
+++ b/connect/template/deps/ubuntu-22.04_optional_packages.txt.jinja2
@@ -1,0 +1,2 @@
+libuv1-dev
+xz-utils

--- a/connect/template/deps/ubuntu-22.04_packages.txt.jinja2
+++ b/connect/template/deps/ubuntu-22.04_packages.txt.jinja2
@@ -11,4 +11,3 @@ libglib2.0-0
 mime-support
 rrdtool
 tzdata
-xz-utils

--- a/connect/template/deps/ubuntu-24.04_optional_packages.txt.jinja2
+++ b/connect/template/deps/ubuntu-24.04_optional_packages.txt.jinja2
@@ -1,0 +1,2 @@
+libuv1-dev
+xz-utils

--- a/connect/template/deps/ubuntu-24.04_packages.txt.jinja2
+++ b/connect/template/deps/ubuntu-24.04_packages.txt.jinja2
@@ -5,4 +5,3 @@ libssl3t64
 media-types
 rrdtool
 tzdata
-xz-utils

--- a/connect/template/test/goss.yaml.jinja2
+++ b/connect/template/test/goss.yaml.jinja2
@@ -31,6 +31,14 @@ package:
   {{ . }}:
     installed: true
   {{ end }}
+  {{ if eq .Env.IMAGE_VARIANT "Standard" }}
+  {{ $apt_optional_package_list_path := printf "/tmp/version/deps/%s-%s_optional_packages.txt" .Env.IMAGE_OS_NAME .Env.IMAGE_OS_VERSION }}
+  {{ $apt_optional_package_list := readFile $apt_optional_package_list_path | splitList "\n" }}
+  {{- range $apt_optional_package_list }}
+  {{ . }}:
+    installed: true
+  {{ end }}
+  {{ end }}
   rstudio-drivers:
     installed: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
   {%- endraw %}


### PR DESCRIPTION
Adds a Standard-only optional system-packages list to the Connect image
(mirroring the Workbench pattern). Standard runs content in local execution
mode and needs build/runtime libraries the Minimal base does not, so these
install only in the Standard variant.

This sets up the mechanism #93 calls for and makes completing it easier, but is
only a partial implementation — it seeds the list rather than defining the full
content-execution package set, which remains open in #93.

- **`libuv1-dev`** — build dependency for the R `fs` package; ports
  connect-content #92.
- **`xz-utils`** — only needed by the Standard-only TinyTeX install, so it moves
  out of the shared base list (Minimal no longer carries it) on the active
  versions.

Related:
- https://github.com/posit-dev/images-connect/issues/93
- https://github.com/posit-dev/images-connect/pull/92
- https://github.com/posit-dev/images-workbench/issues/89
