### PR TITLE
fix: clean up leftover Connect .deb in development images

### DIFF
--- a/connect/template/scripts/install_connect.sh.jinja2
+++ b/connect/template/scripts/install_connect.sh.jinja2
@@ -60,4 +60,7 @@ EOF
 fi
 
 # clean up
+{% if Image.IsDevelopmentVersion -%}
+rm -f /tmp/rstudio-connect.deb
+{% endif -%}
 {{ apt.clean_command() }}


### PR DESCRIPTION
## Summary

Fixes #105.

Development-stream Connect images (`connect-preview:daily`) install Connect from a `.deb` fetched to `/tmp/rstudio-connect.deb`, but that file was never removed, leaving it in the final image:

```
root@…:/# find / -name '*.deb'
/tmp/rstudio-connect.deb
```

This adds an `rm -f /tmp/rstudio-connect.deb` to the clean-up step of `install_connect.sh` for development versions. Released (non-dev) versions install from the apt repo and have no such temp file.

## Changes

- `connect/template/scripts/install_connect.sh.jinja2`: in the clean-up section, remove the fetched `.deb` when `Image.IsDevelopmentVersion`, then run `apt.clean_command()` for **all** variants (dev and released), so apt cache cleanup is preserved everywhere.

## Notes

- Only the template is changed. Released version directories render byte-identically (verified with `bakery update files`); development versions are built dynamically from the `daily` stream and are not committed, so there are no rendered-file changes to include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)