### PR TITLE
Consolidate duplicate Quarto goss test

### DIFF
--- a/connect/2025.05/test/goss.yaml
+++ b/connect/2025.05/test/goss.yaml
@@ -120,6 +120,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: "HOME='/opt' quarto list tools"

--- a/connect/2025.06/test/goss.yaml
+++ b/connect/2025.06/test/goss.yaml
@@ -120,6 +120,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: "HOME='/opt' quarto list tools"

--- a/connect/2025.07/test/goss.yaml
+++ b/connect/2025.07/test/goss.yaml
@@ -120,6 +120,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: "HOME='/opt' quarto list tools"

--- a/connect/2025.09/test/goss.yaml
+++ b/connect/2025.09/test/goss.yaml
@@ -120,6 +120,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: "HOME='/opt' quarto list tools"

--- a/connect/2025.10/test/goss.yaml
+++ b/connect/2025.10/test/goss.yaml
@@ -120,6 +120,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: "HOME='/opt' quarto list tools"

--- a/connect/2025.11/test/goss.yaml
+++ b/connect/2025.11/test/goss.yaml
@@ -128,10 +128,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools

--- a/connect/2025.12/test/goss.yaml
+++ b/connect/2025.12/test/goss.yaml
@@ -128,10 +128,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools

--- a/connect/2026.01/test/goss.yaml
+++ b/connect/2026.01/test/goss.yaml
@@ -128,10 +128,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools

--- a/connect/2026.02/test/goss.yaml
+++ b/connect/2026.02/test/goss.yaml
@@ -128,10 +128,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools

--- a/connect/2026.03/test/goss.yaml
+++ b/connect/2026.03/test/goss.yaml
@@ -128,10 +128,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: quarto list tools

--- a/connect/2026.04/test/goss.yaml
+++ b/connect/2026.04/test/goss.yaml
@@ -128,10 +128,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: "HOME='/opt' quarto list tools"

--- a/connect/2026.05/test/goss.yaml
+++ b/connect/2026.05/test/goss.yaml
@@ -128,10 +128,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
+    timeout: 120000
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Ensure TinyTeX is installed":
     exec: "HOME='/opt' quarto list tools"

--- a/connect/template/test/goss.yaml.jinja2
+++ b/connect/template/test/goss.yaml.jinja2
@@ -148,10 +148,7 @@ command:
   "Ensure Quarto works":
     exec: /usr/local/bin/quarto check --quiet
     exit-status: 0
-    skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
-  "Ensure Quarto symlink works":
-    exec: /usr/local/bin/quarto check --quiet
-    exit-status: 0
+    timeout: 120000
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   "Ensure TinyTeX is installed":
     exec: "HOME='/opt' quarto list tools"


### PR DESCRIPTION
The "Ensure Quarto works" and "Ensure Quarto symlink works" tests in the connect goss suite ran identical commands (`/usr/local/bin/quarto check --quiet`) with identical assertions. Under goss's default concurrency the two invocations appear to race against each other on shared `quarto check` state, producing intermittent exit-1 failures on whichever runs second. Three flakes across three image versions, both architectures, and both supported OS versions are catalogued in the runs below.

Drop the duplicate. The remaining `Ensure Quarto works` test runs via the symlink, and the existing `file:` resources for `/opt/quarto/bin/quarto` and `/usr/local/bin/quarto` (with `linked-to:`) already prove both paths exist and resolve. Also add `timeout: 120000` to match the equivalent test in Workbench, since `quarto check --quiet` exercises the full toolchain and can exceed goss's 10 second default on a busy runner.

Related runs:

- https://github.com/posit-dev/images-connect/actions/runs/26585129484/job/78328943829
- https://github.com/posit-dev/images-connect/actions/runs/26601549462/job/78386252733
- https://github.com/posit-dev/images-connect/actions/runs/26601549462/job/78386260254