### PR TITLE
Add which-image guide and update extending links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,24 @@ For builds using the `bakery` CLI, see the [contributing guide](CONTRIBUTING.md)
 
 To build images with `bakery` or run the test suite, see the [contributing guide](CONTRIBUTING.md).
 
+## Customizing images
+
+Each image serves a different role. The right image to customize depends on what you want to change.
+
+| I want to… | Customize | Example |
+|:-----------|:----------|:--------|
+| Add R or Python packages available to deployed content (Kubernetes) | `connect-content` | [content/r-python-packages](https://github.com/posit-dev/images-examples/tree/main/extending/connect/content/r-python-packages) |
+| Add system libraries that content packages need (Kubernetes) | `connect-content` | [content/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/connect/content/system-dependencies) |
+| Install R on the Connect server (local Docker) | `connect` (Minimal) | [server/R](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/R) |
+| Install Quarto on the Connect server | `connect` (Minimal) | [server/quarto](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/quarto) |
+| Upgrade the Connect server version | `connect` + `connect-content-init` (keep in sync) | — |
+| Add custom runtime components for off-host execution | `connect-content-init` | [Custom container images](https://docs.posit.co/helm/examples/connect/container-images/custom-images.html) |
+
+For detailed guidance and full example code, see the [Connect extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/connect).
+
 ## Related repositories
 
-This repository is part of the [Posit Container Images](https://github.com/posit-dev/images) ecosystem. To extend the Minimal image with additional languages or system dependencies, see the [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending). For shared build tooling and CI workflows, see [images-shared](https://github.com/posit-dev/images-shared).
+This repository is part of the [Posit Container Images](https://github.com/posit-dev/images) ecosystem. For shared build tooling and CI workflows, see [images-shared](https://github.com/posit-dev/images-shared).
 
 ## Share your feedback
 

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ Each image serves a different role. The right image to customize depends on what
 
 | I want to… | Customize | Example |
 |:-----------|:----------|:--------|
-| Add R or Python packages available to deployed content (Kubernetes) | `connect-content` | [content/r-python-packages](https://github.com/posit-dev/images-examples/tree/main/extending/connect/content/r-python-packages) |
-| Add system libraries that content packages need (Kubernetes) | `connect-content` | [content/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/connect/content/system-dependencies) |
-| Install R on the Connect server (local Docker) | `connect` (Minimal) | [server/R](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/R) |
+| Install specific versions of R, Python, or Quarto (Kubernetes) | `connect-content` | [common/R](https://github.com/posit-dev/images-examples/tree/main/extending/common/R) · [common/python](https://github.com/posit-dev/images-examples/tree/main/extending/common/python) |
+| Add system libraries that content packages need (Kubernetes) | `connect-content` | [common/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/common/system-dependencies) |
+| Install R on the Connect server (local Docker) | `connect` (Minimal) | [common/R](https://github.com/posit-dev/images-examples/tree/main/extending/common/R) |
 | Install Quarto on the Connect server | `connect` (Minimal) | [server/quarto](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/quarto) |
-| Configure pip settings (any product) | any | [common/pip-conf](https://github.com/posit-dev/images-examples/tree/main/extending/common/pip-conf) |
+| Configure a Python package index | any | [Admin docs](https://docs.posit.co/connect/admin/python/package-management/#python-package-repositories) |
 | Upgrade the Connect server version | `connect` + `connect-content-init` (keep in sync) | — |
 | Add custom runtime components for off-host execution | `connect-content-init` | [Custom container images](https://docs.posit.co/helm/examples/connect/container-images/custom-images.html) |
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Each image serves a different role. The right image to customize depends on what
 | Add system libraries that content packages need (Kubernetes) | `connect-content` | [content/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/connect/content/system-dependencies) |
 | Install R on the Connect server (local Docker) | `connect` (Minimal) | [server/R](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/R) |
 | Install Quarto on the Connect server | `connect` (Minimal) | [server/quarto](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/quarto) |
+| Point pip at a custom package index | `connect` (Minimal) | [server/pip-conf](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/pip-conf) |
 | Upgrade the Connect server version | `connect` + `connect-content-init` (keep in sync) | — |
 | Add custom runtime components for off-host execution | `connect-content-init` | [Custom container images](https://docs.posit.co/helm/examples/connect/container-images/custom-images.html) |
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Each image serves a different role. The right image to customize depends on what
 | Add system libraries that content packages need (Kubernetes) | `connect-content` | [content/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/connect/content/system-dependencies) |
 | Install R on the Connect server (local Docker) | `connect` (Minimal) | [server/R](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/R) |
 | Install Quarto on the Connect server | `connect` (Minimal) | [server/quarto](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/quarto) |
-| Point pip at a custom package index | `connect` (Minimal) | [server/pip-conf](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server/pip-conf) |
+| Configure pip settings (any product) | any | [common/pip-conf](https://github.com/posit-dev/images-examples/tree/main/extending/common/pip-conf) |
 | Upgrade the Connect server version | `connect` + `connect-content-init` (keep in sync) | — |
 | Add custom runtime components for off-host execution | `connect-content-init` | [Custom container images](https://docs.posit.co/helm/examples/connect/container-images/custom-images.html) |
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Posit publishes additional container images to [Docker Hub](https://hub.docker.c
 
 ## Running the images
 
-For local Docker, you only need the `connect` image. The `connect-content` and `connect-content-init` images are for Kubernetes deployments, where published content runs in separate pods from the Connect server.
+or local Docker, you only need the `connect` image. The `connect-content` and `connect-content-init` images are for [Off-Host Execution (OHE) deployments](https://docs.posit.co/connect/admin/appendix/off-host/arch-overview/#off-host-execution) on Kubernetes, where published content runs in separate pods from the Connect server.
 
 - [Connect](./connect/): the Connect server
 - [Connect Content](./connect-content/): runtime images for executing content (Kubernetes)

--- a/connect-content-init/README.md
+++ b/connect-content-init/README.md
@@ -98,6 +98,8 @@ The container starts as `root` so the entrypoint can write files into the shared
 
 You can extend this image to include additional content beyond the default set. For example, you can add custom R packages, Python packages, or system dependencies that your published content requires. See [Custom Container Images for Connect](https://docs.posit.co/helm/examples/connect/container-images/custom-images.html).
 
+For a full guide to which Connect image to customize for different goals, see the [Connect extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/connect).
+
 ## Migrating from rstudio/rstudio-connect-content-init
 
 This image replaces the legacy [`rstudio/rstudio-connect-content-init`](https://hub.docker.com/r/rstudio/rstudio-connect-content-init) image. The init container behavior is unchanged. The entrypoint copies runtime components into a shared volume at `/mnt/rstudio-connect-runtime` for the Connect content container to consume. The differences lie in how the image is published.

--- a/connect-content/README.md
+++ b/connect-content/README.md
@@ -60,7 +60,7 @@ Two variants are available:
 
 Each tagged image bundles a fixed set of dependencies. Both variants ship one R version, one Python version, and one Quarto version, for a collection of minor versions at their latest patch version available at build time. The Containerfiles in this repository under `connect-content/matrix/` document the exact versions in any tag.
 
-See [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending) for how to build on these images.
+See [content extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/connect/content) for how to build on these images, including pre-installing R packages, Python packages, and system dependencies.
 
 ## Image tags
 
@@ -109,7 +109,7 @@ FROM ghcr.io/posit-dev/connect-content:R4.5.2-python3.14.3-ubuntu-24.04-pro
 RUN /opt/R/4.5.2/bin/R -e 'install.packages("tidyverse", repos = "https://p3m.dev/cran/__linux__/noble/latest")'
 ```
 
-See [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending) for additional patterns.
+See [content extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/connect/content) for additional patterns.
 
 ## Migrating from legacy image
 

--- a/connect/README.md
+++ b/connect/README.md
@@ -115,7 +115,7 @@ Two variants are available:
 
 Each tagged image bundles a fixed set of dependencies. Both variants ship the latest patch of the `YYYY.MM` Connect release available at image build time. The Standard variant additionally ships one R version, one Python version, and one Quarto version, locked to the latest available at release. The Containerfiles in this repository under `connect/<version>/` document the exact versions in any tag.
 
-See [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending) for how to build on the Minimal image.
+See [server extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/connect/server) for how to build on the Minimal image.
 
 ## Image tags
 


### PR DESCRIPTION
Adds a "Customizing images" section to the repo root README with a goal-to-image mapping table. Connect has three images (server, content runtime, init container) that serve distinct roles in Kubernetes deployments.

Updates the per-image extending-example links to point at the relevant `images-examples/extending/connect/...` subfolder rather than the generic `extending/` root.

Depends on (must land first):

- https://github.com/posit-dev/images-examples/pull/36