### PR TITLE
Expand CONTRIBUTING.md with maintainer task guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,11 +175,11 @@ When making changes to the repository, consider whether updates are required for
 
 All workflows call shared reusable workflows from `images-shared`:
 
-| Workflow | Schedule | What it builds | Shared workflow |
-|---|---|---|---|
-| `production.yml` | Weekly (Sun 03:15 UTC), PR, push to main | `connect` + `connect-content-init` (excludes dev/matrix) | `bakery-build-native.yml` |
-| `development.yml` | Daily (04:45 UTC), PR, push to main | Dev versions only (daily stream previews) | `bakery-build-native.yml` |
-| `content.yml` | Weekly (Sun 04:15 UTC), PR, push to main | `connect-content` matrix images only | `bakery-build.yml` |
+| Workflow | What it builds | Shared workflow |
+|---|---|---|
+| `production.yml` | `connect` + `connect-content-init` (excludes dev/matrix) | `bakery-build-native.yml` |
+| `development.yml` | Dev versions only (daily stream previews) | `bakery-build-native.yml` |
+| `content.yml` | `connect-content` matrix images only | `bakery-build.yml` |
 
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.
 Dev preview images push to `ghcr.io/posit-dev/connect-preview`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,15 +184,7 @@ All workflows call shared reusable workflows from `images-shared`:
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.
 Dev preview images push to `ghcr.io/posit-dev/connect-preview`.
 
-### CI failure checklist
-
-1. **Check which workflow failed** — production vs development vs content have different scopes
-2. **Read the failing step** — usually Build or Test
-3. **Common failures:**
-   - Python version not available in UV — a new Python minor version may not be in UV's release metadata yet
-   - Goss test timeout — Connect Standard variant needs `wait: 20` for server startup
-   - Registry auth — Docker Hub push requires `DOCKER_HUB_ACCESS_TOKEN` secret
-4. **Cache issues** — builds use `--cache-registry ghcr.io/posit-dev` for layer caching; stale caches can cause unexpected behavior
+For CI failure diagnosis, see [CONTRIBUTING.md](CONTRIBUTING.md#diagnose-a-build-failure).
 
 ## Helm Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ All workflows call shared reusable workflows from `images-shared`:
 |---|---|---|
 | `production.yml` | `connect` + `connect-content-init` (excludes dev/matrix) | `bakery-build-native.yml` |
 | `development.yml` | Dev versions only (daily stream previews) | `bakery-build-native.yml` |
-| `content.yml` | `connect-content` matrix images only | `bakery-build.yml` |
+| `content.yml` | `connect-content` matrix images only | `bakery-build-native.yml` |
 
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.
 Dev preview images push to `ghcr.io/posit-dev/connect-preview`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,150 @@
 # Contributing to Posit Connect container images
 
-This guide covers how to build and test the Connect container images with the `bakery` CLI. To build images directly with Docker, Buildah, or Podman, see the [README](README.md#build). To deploy or run pre-built images, see the [running the images](README.md#running-the-images) section.
+This guide covers how to build and test the Connect container images locally, and how to
+perform common maintenance tasks. To build images directly with Docker, Buildah, or
+Podman, see the [README](README.md#build). To deploy or run pre-built images, see the
+[README](README.md#running-the-images).
 
-## Using `bakery`
-
-This repository follows the structure described in [bakery usage](https://github.com/posit-dev/images-shared/tree/main/posit-bakery#usage).
-
-Additional documentation:
-- [Configuration reference](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md): `bakery.yaml` schema and options
-- [Templating reference](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/TEMPLATING.md): Jinja2 macros for Containerfile templates
-- [CI workflows](https://github.com/posit-dev/images-shared/blob/main/CI.md): Shared GitHub Actions workflows for building and pushing images
-
-The [`bakery.yaml`](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md#bakery-configuration) file, or project, is in the root of this repository.
+## Build and test
 
 ### Prerequisites
 
-Build prerequisites:
-
-* [python](https://docs.astral.sh/uv/guides/install-python/)
-* [uv](https://docs.astral.sh/uv/getting-started/installation/)
-* [docker buildx bake](https://github.com/docker/buildx#installing)
-* [just](https://just.systems/man/en/prerequisites.html)
-* `bakery`
-
-    ```shell
-    just install-bakery
-    ```
-
-* `goss` and `dgoss` for running image validation tests
-
-    ```shell
-    just install-goss
-    ```
-
-* [`pre-commit`](https://pre-commit.com/) hooks (for contributors)
-
-    ```shell
-    just setup
-    ```
-
-### Build with `bakery`
-
-By default, bakery creates an ephemeral JSON [bakefile](https://docs.bakefile.org/en/latest/language.html) to render all containers in parallel.
+| Tool | Install |
+|---|---|
+| [python](https://docs.astral.sh/uv/guides/install-python/) + [uv](https://docs.astral.sh/uv/getting-started/installation/) | Required for `bakery` |
+| [docker buildx bake](https://github.com/docker/buildx#installing) | Required for builds |
+| [just](https://just.systems/man/en/prerequisites.html) | Task runner |
 
 ```shell
+# Install bakery and goss
+just init
+
+# Install pre-commit hooks
+just setup
+```
+
+### Build
+
+```shell
+# Preview the build plan
+bakery build --plan
+
+# Build all images
 bakery build
+
+# Build a specific image, version, and variant
+bakery build --image-name connect --image-version 2026.05 --image-variant Standard
 ```
 
-You can view the bake plan using `bakery build --plan`.
-
-You can use CLI flags to build only a subset of images in the project.
-
-### Test images
-
-After building the container images, run the test suite for all images:
+### Test
 
 ```shell
+# Run goss tests for all images
 bakery run dgoss
+
+# Run goss tests for a specific image
+bakery run dgoss --image-name connect
 ```
 
-You can use CLI flags to limit the tests to run against a subset of images.
+### Re-render templates
+
+After changing any file in a `template/` directory, re-render the version directories:
+
+```shell
+bakery update files
+bakery update files --image-name connect --image-version 2026.05
+```
+
+## Maintainer tasks
+
+Each section below has Connect-specific context and a concrete example. The linked
+procedure in the [shared maintainer guide](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md)
+covers the full workflow.
+
+### Add a version
+
+Connect versions are dispatched automatically from `posit-dev/connect` via the
+`posit-connect-projects` GitHub App, which triggers this repo's `release.yml` workflow.
+Manual steps are only needed for hotfixes or if the automated dispatch fails.
+
+```bash
+# Create a new version manually (e.g. a hotfix to 2026.05)
+bakery create version 2026.05.2 --image-name connect --image-name connect-content-init
+bakery update files --image-name connect --image-version 2026.05
+bakery update files --image-name connect-content-init --image-version 2026.05
+```
+
+`connect-content` is a matrix image. Its versions are managed via `matrixVersions` in
+`bakery.yaml`, not with `bakery create version`.
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#add-a-version)
+
+### Add an image
+
+This repo has three images: `connect` (server), `connect-content` (R×Python matrix for
+Launcher), and `connect-content-init` (Kubernetes init container). Adding a new image
+requires coordination with the Connect product team to define the new service role.
+
+```bash
+# Scaffold a new image directory and template
+bakery create image <new-image-name>
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#add-an-image)
+
+### Update dependencies
+
+`connect` and `connect-content-init` use `dependencyConstraints: latest: true` for R,
+Python, and Quarto — bakery resolves the current latest at build time.
+
+`connect-content` is a matrix image. Its R×Python combinations are defined in
+`bakery.yaml` under `matrixVersions`. To add a new R or Python version to the matrix,
+add it to `matrixVersions` and re-render:
+
+```bash
+bakery update files --image-name connect-content
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#update-dependencies)
+
+### Update older versions
+
+```bash
+# Edit the template, then re-render a specific edition
+bakery update files --image-name connect --image-version 2026.04
+bakery update files --image-name connect-content-init --image-version 2026.04
+
+# Build and test before opening a PR
+bakery build --image-name connect --image-version 2026.04
+bakery run dgoss --image-name connect --image-version 2026.04
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#update-older-versions)
+
+### Footguns
+
+**Connect Standard goss needs `wait: 20`.** The Connect server takes ~20 seconds to
+start. The Standard variant's `options` block in `bakery.yaml` sets `wait: 20`. Lowering
+or removing it causes flaky goss failures on slower runners.
+
+**`connect-content` has no version directories.** It renders into
+`connect-content/matrix/`. Do not create `connect-content/<edition>/` directories
+manually.
+
+→ [Shared footguns](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#footguns)
+
+### Diagnose a build failure
+
+| Workflow | Schedule | Builds |
+|---|---|---|
+| `production.yml` | Weekly Sun 02:15 UTC, push to main, dispatch | `connect` + `connect-content-init` (excludes dev and matrix) |
+| `development.yml` | Daily 08:45 UTC, push to main, dispatch | Dev stream previews → `ghcr.io/posit-dev/connect-preview` |
+| `content.yml` | Weekly Sun 02:45 UTC, push to main, dispatch | `connect-content` matrix images only |
+
+All workflows use `bakery-build-native.yml` (native amd64 + arm64 runners).
+
+**Connect-specific failure:** goss timeout on the Standard variant. The Connect server
+takes ~20s to start. If goss probes fail immediately, check that `options.wait: 20` is
+still set in `bakery.yaml`.
+
+→ [Shared failure scenarios](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#diagnose-a-build-failure)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,10 @@ covers the full workflow.
 
 Connect versions are dispatched automatically from `posit-dev/connect` via the
 `posit-connect-projects` GitHub App, which triggers this repo's `release.yml` workflow.
-Manual steps are only needed for hotfixes or if the automated dispatch fails.
+Use manual steps only for hotfixes or if the automated dispatch fails.
 
 ```bash
-# Create a new version manually (e.g. a hotfix to 2026.05)
+# Create a new version manually (e.g., a hotfix to 2026.05)
 bakery create version 2026.05.2 --image-name connect --image-name connect-content-init
 bakery update files --image-name connect --image-version 2026.05
 bakery update files --image-name connect-content-init --image-version 2026.05
@@ -125,13 +125,9 @@ bakery run dgoss --image-name connect --image-version 2026.04
 
 ### Footguns
 
-**Connect Standard goss needs `wait: 20`.** The Connect server takes ~20 seconds to
-start. The Standard variant's `options` block in `bakery.yaml` sets `wait: 20`. Lowering
-or removing it causes flaky goss failures on slower runners.
+- **Connect Standard goss needs `wait: 20`.** The Connect server takes ~20 seconds to start. The Standard variant's `options` block in `bakery.yaml` sets `wait: 20`. Lowering or removing it causes flaky goss failures on slower runners.
 
-**`connect-content` has no version directories.** It renders into
-`connect-content/matrix/`. Do not create `connect-content/<edition>/` directories
-manually.
+- **`connect-content` has no version directories.** It renders into `connect-content/matrix/`. Do not create `connect-content/<edition>/` directories manually.
 
 → [Shared footguns](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#footguns)
 
@@ -145,7 +141,7 @@ manually.
 
 All workflows use `bakery-build-native.yml` (native amd64 + arm64 runners).
 
-**Connect-specific failure:** goss timeout on the Standard variant. The Connect server
+Connect-specific failure: goss timeout on the Standard variant. The Connect server
 takes ~20s to start. If goss probes fail immediately, check that `options.wait: 20` is
 still set in `bakery.yaml`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,8 @@ bakery run dgoss --image-name connect
 After changing any file in a `template/` directory, re-render the version directories:
 
 ```shell
-bakery update files
+# Omitting filters re-renders every image and version; --help shows available filters
+bakery update files --help
 bakery update files --image-name connect --image-version 2026.05
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,8 @@ bakery update files --image-name connect --image-version 2026.05
 bakery update files --image-name connect-content-init --image-version 2026.05
 ```
 
-`connect-content` is a matrix image. Its versions are managed via `matrixVersions` in
-`bakery.yaml`, not with `bakery create version`.
+`connect-content` is a matrix image. Its versions are managed via
+`matrix.dependencyConstraints` in `bakery.yaml`, not with `bakery create version`.
 
 → [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#add-a-version)
 
@@ -94,12 +94,14 @@ bakery create image <new-image-name>
 
 ### Update dependencies
 
-`connect` and `connect-content-init` use `dependencyConstraints: latest: true` for R,
-Python, and Quarto — bakery resolves the current latest at build time.
+`connect` uses `dependencyConstraints: latest: true` for R, Python, and Quarto — bakery
+resolves the current latest at build time. `connect-content-init` has no dependency
+constraints.
 
 `connect-content` is a matrix image. Its R×Python combinations are defined in
-`bakery.yaml` under `matrixVersions`. To add a new R or Python version to the matrix,
-add it to `matrixVersions` and re-render:
+`bakery.yaml` under `matrix.dependencyConstraints`. To add a new R or Python version to
+the matrix, update the image's `matrix.dependencyConstraints` block in `bakery.yaml` and
+re-render:
 
 ```bash
 bakery update files --image-name connect-content

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ For builds using the `bakery` CLI, see the [contributing guide](CONTRIBUTING.md)
 ## Contributing
 
 To build images with `bakery` or run the test suite, see the [contributing guide](CONTRIBUTING.md).
+For image maintainers, the contributing guide also covers adding versions, updating
+dependencies, backporting to older versions, known footguns, and CI failure diagnosis.
 
 ## Related repositories
 


### PR DESCRIPTION
The existing CONTRIBUTING.md covered only local build and test. A new maintainer had no documented path for the six most common operations: adding a version, adding an image, updating dependencies, backporting to older versions, avoiding footguns, and diagnosing CI failures.

This rewrites CONTRIBUTING.md with a maintainer task guide. Each section has Connect-specific context and a concrete example inline, then links to the shared procedure in images-shared for depth.

Also:
- Removes the CI failure checklist from CLAUDE.md — content now lives in CONTRIBUTING.md
- Removes the schedule column from the CLAUDE.md CI workflow table (schedules are the authoritative version in CONTRIBUTING.md, eliminating the drift that caused stale values)
- Corrects several pre-existing inaccuracies in the CI workflow table (wrong workflow names, wrong shared workflow name for `content.yml`)

Part of a coordinated change across four repos:
- https://github.com/posit-dev/images-shared/pull/564
- https://github.com/posit-dev/images-package-manager/pull/102
- https://github.com/posit-dev/images-workbench/pull/124