### PR TITLE
Use dev-version/dev-channel for dispatched dev builds

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -17,7 +17,7 @@ on:
         description: "CDN-formatted version string (e.g. '2026.06.0-dev+159-gfc86f5da40'). When set, bakery asserts the CDN manifest matches before building."
         required: false
         type: string
-      stream:
+      channel:
         description: "Dev channel to build (e.g. 'daily'). When set, only that channel is built."
         required: false
         type: string
@@ -67,7 +67,7 @@ jobs:
       dev-versions: "only"
       matrix-versions: "exclude"
       dev-version: ${{ inputs.version }}
-      dev-channel: ${{ inputs.stream }}
+      dev-channel: ${{ inputs.channel }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -14,11 +14,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Product version to build (e.g. 2026.04.0)"
+        description: "CDN-formatted version string (e.g. '2026.06.0-dev+159-gfc86f5da40'). When set, bakery asserts the CDN manifest matches before building."
         required: false
         type: string
       stream:
-        description: "Dev stream to build (e.g. 'daily')"
+        description: "Dev channel to build (e.g. 'daily'). When set, only that channel is built."
         required: false
         type: string
 
@@ -66,8 +66,8 @@ jobs:
     with:
       dev-versions: "only"
       matrix-versions: "exclude"
-      image-version: ${{ inputs.version }}
-      dev-stream: ${{ inputs.stream }}
+      dev-version: ${{ inputs.version }}
+      dev-channel: ${{ inputs.stream }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,6 +21,10 @@ on:
         description: "Dev channel to build (e.g. 'daily'). When set, only that channel is built."
         required: false
         type: string
+      stream:
+        description: "Deprecated: use channel instead."
+        required: false
+        type: string
 
 
 concurrency:
@@ -67,7 +71,7 @@ jobs:
       dev-versions: "only"
       matrix-versions: "exclude"
       dev-version: ${{ inputs.version }}
-      dev-channel: ${{ inputs.channel }}
+      dev-channel: ${{ inputs.channel || inputs.stream }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
Switches `development.yml` from `image-version`/`dev-stream` to `dev-version`/`dev-channel`, matching the interface added in posit-dev/images-shared#565. Adds `channel` as the new dispatch input and keeps `stream` as a deprecated alias so existing callers are not broken until they migrate.

Must be merged before:
- https://github.com/posit-dev/connect/pull/40410
- https://github.com/posit-dev/images-connect/pull/121