### PR TITLE
Remove deprecated stream input from development.yml

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,10 +21,6 @@ on:
         description: "Dev channel to build (e.g. 'daily'). When set, only that channel is built."
         required: false
         type: string
-      stream:
-        description: "Deprecated: use channel instead."
-        required: false
-        type: string
 
 
 concurrency:
@@ -71,7 +67,7 @@ jobs:
       dev-versions: "only"
       matrix-versions: "exclude"
       dev-version: ${{ inputs.version }}
-      dev-channel: ${{ inputs.channel || inputs.stream }}
+      dev-channel: ${{ inputs.channel }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
Removes the `stream` compatibility alias added in #120, now that all callers have switched to `channel`.

Must be merged after:
- https://github.com/posit-dev/images-connect/pull/120
- https://github.com/posit-dev/connect/pull/40410