### PR TITLE
Fix license file activation for non-root containers

### DIFF
--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -47,9 +47,15 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    rm -f "${_license_dir}"/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-    chmod 0600 "${_license_dir}/license.lic"
+    case "$(realpath "$PCT_LICENSE_FILE_PATH")" in
+        "${_license_dir}/"*)
+            ;;
+        *)
+            rm -f "${_license_dir}"/*.lic
+            cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
+            ;;
+    esac
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -47,14 +47,9 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
-        if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
-            exit 1
-        fi
-        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
-        chmod 0600 "${_license_dir}/license.lic"
-    fi
+    rm -f "${_license_dir}"/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -53,9 +53,9 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
         *)
             rm -f "${_license_dir}"/*.lic
             cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+            chmod 0600 "${_license_dir}/license.lic"
             ;;
     esac
-    chmod 0600 "${_license_dir}/license.lic"
     echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in ${_license_dir}/." >&2


### PR DESCRIPTION
\`license-manager activate-file\` hard-rejects non-root callers, crashing the container when \`runAsNonRoot: true\` is set.

File-based licenses don't need activation — Connect reads any \`*.lic\` file in \`/var/lib/rstudio-connect/\` natively. We can just put the file there.

Writing the license into a mounted volume is problematic: it pollutes shared persistent storage, risks race conditions in multi-pod deployments, and has no benefit since the source file is already accessible. This PR detects that case at startup and fails with a clear error directing users to mount the license Secret directly via \`subPath\` instead.

Reported via Zendesk ticket 130129 (Connect on AKS with \`runAsUser: 999\`).