### PR TITLE
Add deprecate-editions workflow; switch release to client-id

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -1,0 +1,18 @@
+name: Deprecate Editions
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch: {}
+
+jobs:
+  deprecate:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: posit-dev/images-shared/.github/workflows/deprecate-editions.yml@main
+    with:
+      images: "connect connect-content-init"
+    secrets:
+      CLIENT_ID: ${{ secrets.POSIT_CONNECT_PROJECTS_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,5 @@ jobs:
       version: ${{ inputs.version }}
       images: "connect connect-content-init"
     secrets:
-      APP_ID: ${{ secrets.POSIT_CONNECT_PROJECTS_APP_ID }}
+      CLIENT_ID: ${{ secrets.POSIT_CONNECT_PROJECTS_CLIENT_ID }}
       APP_PRIVATE_KEY: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.05/scripts/startup.sh
+++ b/connect/2025.05/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.06/scripts/startup.sh
+++ b/connect/2025.06/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.07/scripts/startup.sh
+++ b/connect/2025.07/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.09/scripts/startup.sh
+++ b/connect/2025.09/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.10/scripts/startup.sh
+++ b/connect/2025.10/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.11/scripts/startup.sh
+++ b/connect/2025.11/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2025.12/scripts/startup.sh
+++ b/connect/2025.12/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.01/scripts/startup.sh
+++ b/connect/2026.01/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.02/scripts/startup.sh
+++ b/connect/2026.02/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.03/scripts/startup.sh
+++ b/connect/2026.03/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.04/scripts/startup.sh
+++ b/connect/2026.04/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/2026.05/scripts/startup.sh
+++ b/connect/2026.05/scripts/startup.sh
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -46,11 +46,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    _tmp_lic=$(mktemp)
-    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
-    rm -f /var/lib/rstudio-connect/*.lic
-    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
-    chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+        chmod 0600 /var/lib/rstudio-connect/license.lic
+    fi
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -39,11 +39,9 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 _license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
-    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
-    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
@@ -51,15 +49,15 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
         if mountpoint -q "${_license_dir}"; then
-            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH." >&2
             exit 1
         fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi
-    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}." >&2
 elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
-    echo "Detected a license file in ${_license_dir}/."
+    echo "Detected a license file in ${_license_dir}/." >&2
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -44,6 +44,8 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
+    # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     _tmp_lic=$(mktemp)
     cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -50,6 +50,10 @@ elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
     if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        if mountpoint -q "${_license_dir}"; then
+            echo "ERROR: ${_license_dir} is a volume mount. Mount the license file directly into ${_license_dir}/ instead of using PCT_LICENSE_FILE_PATH."
+            exit 1
+        fi
         cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
         chmod 0600 "${_license_dir}/license.lic"
     fi

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -37,19 +37,25 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 
 # Activate License
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+_license_dir=/var/lib/rstudio-connect
 if ! [ -z "$PCT_LICENSE" ]; then
+    echo "Activating license key."
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
     trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
+    echo "Activating floating license server."
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
     # Direct copy avoids activate-file's root requirement and activation-slot lease risk.
     # https://docs.posit.co/connect/admin/licensing/#license-file-activation
-    if [ "${PCT_LICENSE_FILE_PATH}" != "/var/lib/rstudio-connect/license.lic" ]; then
-        cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-        chmod 0600 /var/lib/rstudio-connect/license.lic
+    if [ "$(dirname "${PCT_LICENSE_FILE_PATH}")" != "${_license_dir}" ]; then
+        cp "${PCT_LICENSE_FILE_PATH}" "${_license_dir}/license.lic"
+        chmod 0600 "${_license_dir}/license.lic"
     fi
+    echo "Using license file at ${PCT_LICENSE_FILE_PATH}."
+elif ls "${_license_dir}"/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in ${_license_dir}/."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -44,8 +44,10 @@ elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
     trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
+    _tmp_lic=$(mktemp)
+    cp "${PCT_LICENSE_FILE_PATH}" "${_tmp_lic}"
     rm -f /var/lib/rstudio-connect/*.lic
-    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    mv "${_tmp_lic}" /var/lib/rstudio-connect/license.lic
     chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 

--- a/connect/template/scripts/startup.sh.jinja2
+++ b/connect/template/scripts/startup.sh.jinja2
@@ -6,7 +6,7 @@ if [[ "${PCT_STARTUP_DEBUG:-0}" -eq 1 ]]; then
   set -x
 fi
 
-# Deactivate license when it exists
+# Deactivate license when it exists (only used for key/server license modes)
 deactivate() {
     echo "Deactivating license ..."
     is_deactivated=0
@@ -29,7 +29,6 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Backward compatibility for RSC_ prefixed environment variables
 PCT_LICENSE=${PCT_LICENSE:-$RSC_LICENSE}
@@ -40,10 +39,14 @@ PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-$RSC_LICENSE_FILE_PATH}
 PCT_LICENSE_FILE_PATH=${PCT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$PCT_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate "$PCT_LICENSE"
+    trap deactivate EXIT
 elif ! [ -z "$PCT_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server "$PCT_LICENSE_SERVER"
+    trap deactivate EXIT
 elif test -f "$PCT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file "$PCT_LICENSE_FILE_PATH"
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${PCT_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod 0600 /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes


### PR DESCRIPTION
Adds a scheduled workflow that runs on the 1st of each month and creates a PR to remove product editions older than 18 months (per the Posit supported-versions policy). This stops those editions from being built going forward — it does not remove any already-published images from Docker Hub or GHCR.

Also switches the release workflow from the legacy `app-id` GitHub App input to `client-id`, as recommended by `actions/create-github-app-token`.

Depends on posit-dev/images-shared being merged first.