### PR TITLE
Re-render: add uv self update before Python install

### DIFF
--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -6,7 +6,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
 ARG PYTHON_VERSION
-RUN uv python install $PYTHON_VERSION
+RUN uv self update && uv python install $PYTHON_VERSION
 RUN mv /opt/python/cpython-$PYTHON_VERSION-linux-*/ /opt/python/$PYTHON_VERSION
 
 

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -6,7 +6,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
 ARG PYTHON_VERSION
-RUN uv python install $PYTHON_VERSION
+RUN uv self update && uv python install $PYTHON_VERSION
 RUN mv /opt/python/cpython-$PYTHON_VERSION-linux-*/ /opt/python/$PYTHON_VERSION
 
 

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -6,7 +6,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
 ARG PYTHON_VERSION
-RUN uv python install $PYTHON_VERSION
+RUN uv self update && uv python install $PYTHON_VERSION
 RUN mv /opt/python/cpython-$PYTHON_VERSION-linux-*/ /opt/python/$PYTHON_VERSION
 
 

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -6,7 +6,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
 ARG PYTHON_VERSION
-RUN uv python install $PYTHON_VERSION
+RUN uv self update && uv python install $PYTHON_VERSION
 RUN mv /opt/python/cpython-$PYTHON_VERSION-linux-*/ /opt/python/$PYTHON_VERSION
 
 

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.12.1
+RUN uv self update && uv python install 3.12.1
 RUN mv /opt/python/cpython-3.12.1-linux-*/ /opt/python/3.12.1
 
 

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.12.1
+RUN uv self update && uv python install 3.12.1
 RUN mv /opt/python/cpython-3.12.1-linux-*/ /opt/python/3.12.1
 
 

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.12.1
+RUN uv self update && uv python install 3.12.1
 RUN mv /opt/python/cpython-3.12.1-linux-*/ /opt/python/3.12.1
 
 

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.13.7
+RUN uv self update && uv python install 3.13.7
 RUN mv /opt/python/cpython-3.13.7-linux-*/ /opt/python/3.13.7
 
 

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.0
+RUN uv self update && uv python install 3.14.0
 RUN mv /opt/python/cpython-3.14.0-linux-*/ /opt/python/3.14.0
 
 

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.3
+RUN uv self update && uv python install 3.14.3
 RUN mv /opt/python/cpython-3.14.3-linux-*/ /opt/python/3.14.3
 
 

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.3
+RUN uv self update && uv python install 3.14.3
 RUN mv /opt/python/cpython-3.14.3-linux-*/ /opt/python/3.14.3
 
 

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.3
+RUN uv self update && uv python install 3.14.3
 RUN mv /opt/python/cpython-3.14.3-linux-*/ /opt/python/3.14.3
 
 

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.3
+RUN uv self update && uv python install 3.14.3
 RUN mv /opt/python/cpython-3.14.3-linux-*/ /opt/python/3.14.3
 
 

--- a/connect/2026.04/Containerfile.ubuntu2204.std
+++ b/connect/2026.04/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.4
+RUN uv self update && uv python install 3.14.4
 RUN mv /opt/python/cpython-3.14.4-linux-*/ /opt/python/3.14.4
 
 

--- a/connect/2026.04/Containerfile.ubuntu2404.std
+++ b/connect/2026.04/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.4
+RUN uv self update && uv python install 3.14.4
 RUN mv /opt/python/cpython-3.14.4-linux-*/ /opt/python/3.14.4
 
 

--- a/connect/2026.05/Containerfile.ubuntu2204.std
+++ b/connect/2026.05/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.5
+RUN uv self update && uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 

--- a/connect/2026.05/Containerfile.ubuntu2404.std
+++ b/connect/2026.05/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.5
+RUN uv self update && uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 


### PR DESCRIPTION
Applies `uv self update && uv python install` in all rendered Connect Containerfiles, matching the pattern introduced in posit-dev/images-shared#597.