### PR TITLE
Suppress Quarto TinyTeX progress spam in builds (CI=true)

### DIFF
--- a/connect-content/matrix/Containerfile.ubuntu2204.base
+++ b/connect-content/matrix/Containerfile.ubuntu2204.base
@@ -84,5 +84,5 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2204.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2204.pro
@@ -95,5 +95,5 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.base
+++ b/connect-content/matrix/Containerfile.ubuntu2404.base
@@ -84,5 +84,5 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect-content/matrix/Containerfile.ubuntu2404.pro
+++ b/connect-content/matrix/Containerfile.ubuntu2404.pro
@@ -95,5 +95,5 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json

--- a/connect/2025.05/Containerfile.ubuntu2204.std
+++ b/connect/2025.05/Containerfile.ubuntu2204.std
@@ -92,7 +92,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.06/Containerfile.ubuntu2204.std
+++ b/connect/2025.06/Containerfile.ubuntu2204.std
@@ -92,7 +92,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.07/Containerfile.ubuntu2204.std
+++ b/connect/2025.07/Containerfile.ubuntu2204.std
@@ -92,7 +92,7 @@ RUN mkdir -p /opt/quarto/1.4.557 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/1.4.557/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.09/Containerfile.ubuntu2204.std
+++ b/connect/2025.09/Containerfile.ubuntu2204.std
@@ -92,7 +92,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.10/Containerfile.ubuntu2204.std
+++ b/connect/2025.10/Containerfile.ubuntu2204.std
@@ -92,7 +92,7 @@ RUN mkdir -p /opt/quarto/1.8.25 && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/1.8.25/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Install TensorFlow Serving ###

--- a/connect/2025.11/Containerfile.ubuntu2204.std
+++ b/connect/2025.11/Containerfile.ubuntu2204.std
@@ -100,7 +100,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2025.12/Containerfile.ubuntu2204.std
+++ b/connect/2025.12/Containerfile.ubuntu2204.std
@@ -100,7 +100,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2025.12/Containerfile.ubuntu2404.std
+++ b/connect/2025.12/Containerfile.ubuntu2404.std
@@ -100,7 +100,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.01/Containerfile.ubuntu2204.std
+++ b/connect/2026.01/Containerfile.ubuntu2204.std
@@ -100,7 +100,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.01/Containerfile.ubuntu2404.std
+++ b/connect/2026.01/Containerfile.ubuntu2404.std
@@ -100,7 +100,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.02/Containerfile.ubuntu2204.std
+++ b/connect/2026.02/Containerfile.ubuntu2204.std
@@ -100,7 +100,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.02/Containerfile.ubuntu2404.std
+++ b/connect/2026.02/Containerfile.ubuntu2404.std
@@ -100,7 +100,7 @@ RUN --mount=type=secret,id=github_token,required=false \
         xz-utils && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/* && \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2204.std
+++ b/connect/2026.03/Containerfile.ubuntu2204.std
@@ -95,7 +95,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.03/Containerfile.ubuntu2404.std
+++ b/connect/2026.03/Containerfile.ubuntu2404.std
@@ -95,7 +95,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.04/Containerfile.ubuntu2204.std
+++ b/connect/2026.04/Containerfile.ubuntu2204.std
@@ -95,7 +95,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.04/Containerfile.ubuntu2404.std
+++ b/connect/2026.04/Containerfile.ubuntu2404.std
@@ -95,7 +95,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.05/Containerfile.ubuntu2204.std
+++ b/connect/2026.05/Containerfile.ubuntu2204.std
@@ -96,7 +96,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###

--- a/connect/2026.05/Containerfile.ubuntu2404.std
+++ b/connect/2026.05/Containerfile.ubuntu2404.std
@@ -96,7 +96,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 ### Create data volume ###


### PR DESCRIPTION
Quarto renders an animated TinyTeX download progress bar unless `runningInCI()` passes. The env vars it checks (`CI`, `GITHUB_ACTIONS`, …) do not reach a `docker build` RUN step, so Quarto redraws the bar on every download tick — tens of thousands of lines in a non-TTY build log (a comparable Workbench build emitted ~26,000, ~5 MB).

Setting `CI=true` inline on the install command collapses the progress bar to a single line while keeping error output (unlike `--quiet`). The fix lives in the shared bakery macro (images-shared#627, merged); this adds it directly to the committed Containerfiles so builds get it without waiting for a re-render.

- https://github.com/posit-dev/images-shared/pull/627